### PR TITLE
Filter out relations over a threshold

### DIFF
--- a/python/dmpworks/sql/audits/assert_max_array_length.sql
+++ b/python/dmpworks/sql/audits/assert_max_array_length.sql
@@ -1,0 +1,48 @@
+AUDIT (
+  name assert_max_institutions_length
+);
+SELECT *
+FROM @this_model
+WHERE array_length(@column) > @threshold;
+
+AUDIT (
+  name assert_max_authors_length
+);
+SELECT *
+FROM @this_model
+WHERE array_length(@column) > @threshold;
+
+AUDIT (
+  name assert_max_funders_length
+);
+SELECT *
+FROM @this_model
+WHERE array_length(@column) > @threshold;
+
+AUDIT (
+  name assert_max_awards_length
+);
+SELECT *
+FROM @this_model
+WHERE array_length(@column) > @threshold;
+
+AUDIT (
+  name assert_max_intra_work_dois_length
+);
+SELECT *
+FROM @this_model
+WHERE array_length(@column) > @threshold;
+
+AUDIT (
+  name assert_max_possible_shared_project_dois_length
+);
+SELECT *
+FROM @this_model
+WHERE array_length(@column) > @threshold;
+
+AUDIT (
+  name assert_max_dataset_citation_dois_length
+);
+SELECT *
+FROM @this_model
+WHERE array_length(@column) > @threshold;

--- a/python/dmpworks/sql/commands.py
+++ b/python/dmpworks/sql/commands.py
@@ -30,43 +30,54 @@ def sqlmesh_dir(module_name: str = "dmpworks.sql") -> pathlib.Path:
     return Path(spec.origin).parent
 
 
-def run_plan() -> Plan:
+def run_plan() -> Plan | None:
     """Run the SQLMesh plan command.
 
     Configures the console and executes a plan in the 'prod' environment.
 
     Returns:
-        The executed Plan object.
+        The executed Plan object or None.
     """
     configure_console(ignore_warnings=False)
     ctx = Context(
         paths=[sqlmesh_dir()],
         load=True,
     )
-    return ctx.plan(
-        environment="prod",
-        run=True,
-        ignore_cron=True,
-        auto_apply=True,
-        no_prompts=True,
-    )
+
+    try:
+        return ctx.plan(
+            environment="prod",
+            run=True,
+            ignore_cron=True,
+            auto_apply=True,
+            no_prompts=True,
+        )
+    finally:
+        # Need to close otherwise DuckDB database is not closed properly
+        # and we end up with a db.db.wal and views not always written out
+        ctx.close()
 
 
-def run_test() -> ModelTextTestResult:
+def run_test() -> ModelTextTestResult | None:
     """Run SQLMesh tests.
 
     Configures the console and runs tests with very verbose output.
 
     Returns:
-        The result of the tests.
+        The result of the tests or None.
     """
     configure_console(ignore_warnings=False)
     ctx = Context(
         paths=[sqlmesh_dir()],
         load=True,
     )
-    test_results: ModelTextTestResult = ctx.test(verbosity=Verbosity.VERY_VERBOSE)
-    return test_results
+    try:
+        test_results: ModelTextTestResult = ctx.test(verbosity=Verbosity.VERY_VERBOSE)
+        return test_results
+    finally:
+        # Need to close otherwise DuckDB database is not closed properly
+        # and we end up with a db.db.wal and views not always written out
+        ctx.close()
 
 
 def init_doi_state(file_path: pathlib.Path):

--- a/python/dmpworks/sql/config.yaml
+++ b/python/dmpworks/sql/config.yaml
@@ -5,7 +5,7 @@ gateways:
       # https://sqlmesh.readthedocs.io/en/stable/reference/configuration/#connections
       # https://sqlmesh.readthedocs.io/en/stable/integrations/engines/duckdb/#connection-options
       type: duckdb
-      database: /path/to/db.db
+      database: {{ env_var('DUCKDB_DATABASE') }}
       # concurrent_tasks: 1
       # register_comments: True
       # pre_ping: False
@@ -13,63 +13,72 @@ gateways:
       # catalogs:
       # extensions:
       connector_config:
-        threads: 1
-        memory_limit: '225GB'
+        threads: {{ env_var('DUCKDB_THREADS') }}
+        memory_limit: {{ env_var('DUCKDB_MEMORY_LIMIT') }}
         preserve_insertion_order: 'false'
       # secrets:
       # token:
 
 variables:
-  opensearch_path: "/path/to/opensearch"
-  crossref_metadata_path: "/path/to/crossref_metadata"
-  datacite_path: "/path/to/datacite"
-  openalex_works_path: "/path/to/openalex_works"
-  ror_path: "/path/to/ror"
-  data_citation_corpus_path: "/path/to/data_citation_corpus"
-  works_index_export_path: "/path/to/works_index_export"
-  doi_state_export_path: "/path/to/doi_state_export"
-  audit_crossref_metadata_works_threshold: 167008747
-  audit_datacite_works_threshold: 72019576
-  audit_openalex_works_threshold: 264675126
+  # Data paths
+  crossref_metadata_path: {{ env_var('CROSSREF_METADATA_PATH') }}
+  data_citation_corpus_path: {{ env_var('DATA_CITATION_CORPUS_PATH') }}
+  datacite_path: {{ env_var('DATACITE_PATH') }}
+  doi_state_export_path: {{ env_var('DOI_STATE_EXPORT_PATH') }}
+  openalex_works_path: {{ env_var('OPENALEX_WORKS_PATH') }}
+  opensearch_path: {{ env_var('OPENSEARCH_PATH') }}
+  ror_path: {{ env_var('ROR_PATH') }}
+  works_index_export_path: {{ env_var('WORKS_INDEX_EXPORT_PATH') }}
 
-  crossref_crossref_metadata_threads: 32
-  crossref_index_works_metadata_threads: 32
-  datacite_datacite_threads: 32
-  datacite_index_awards_threads: 32
-  datacite_index_datacite_index_threads: 32
-  datacite_index_funders_threads: 32
-  datacite_index_institutions_threads: 32
-  datacite_index_updated_dates_threads: 32
-  datacite_index_work_types_threads: 32
-  datacite_index_works_threads: 32
-  datacite_index_datacite_index_hashes_threads: 32
-  openalex_openalex_works_threads: 32
-  openalex_index_abstract_stats_threads: 32
-  openalex_index_abstracts_threads: 32
-  openalex_index_author_names_threads: 32
-  openalex_index_awards_threads: 32
-  openalex_index_funders_threads: 32
-  openalex_index_openalex_index_threads: 32
-  openalex_index_publication_dates_threads: 32
-  openalex_index_title_stats_threads: 32
-  openalex_index_titles_threads: 32
-  openalex_index_updated_dates_threads: 32
-  openalex_index_works_metadata_threads: 32
-  openalex_index_openalex_index_hashes_threads: 32
-  opensearch_current_doi_state_threads: 32
-  opensearch_export_threads: 32
-  opensearch_next_doi_state_threads: 32
-  data_citation_corpus_relations_threads: 32
-  relations_crossref_metadata_threads: 32
-  relations_data_citation_corpus_threads: 32
-  relations_datacite_threads: 16
-  relations_relations_index_threads: 32
-  ror_index_threads: 32
-  ror_ror_threads: 32
-  works_index_export_threads: 32
+  # Audits
+  audit_crossref_metadata_works_threshold: {{ env_var('AUDIT_CROSSREF_METADATA_WORKS_THRESHOLD') }}
+  audit_datacite_works_threshold: {{ env_var('AUDIT_DATACITE_WORKS_THRESHOLD') }}
+  audit_nested_object_limit: {{ env_var('AUDIT_NESTED_OBJECT_LIMIT') }}
+  audit_openalex_works_threshold: {{ env_var('AUDIT_OPENALEX_WORKS_THRESHOLD') }}
 
-  max_doi_states: 3
+  # Other settings
+  max_doi_states: {{ env_var('MAX_DOI_STATES') }}
+  max_relation_degrees: {{ env_var('MAX_RELATION_DEGREES') }}
   process_works_run_id: {{ env_var('PROCESS_WORKS_RUN_ID') }}
+
+  # Threads
+  crossref_crossref_metadata_threads: {{ env_var('CROSSREF_CROSSREF_METADATA_THREADS') }}
+  crossref_index_works_metadata_threads: {{ env_var('CROSSREF_INDEX_WORKS_METADATA_THREADS') }}
+  data_citation_corpus_relations_threads: {{ env_var('DATA_CITATION_CORPUS_RELATIONS_THREADS') }}
+  datacite_datacite_threads: {{ env_var('DATACITE_DATACITE_THREADS') }}
+  datacite_index_awards_threads: {{ env_var('DATACITE_INDEX_AWARDS_THREADS') }}
+  datacite_index_datacite_index_hashes_threads: {{ env_var('DATACITE_INDEX_DATACITE_INDEX_HASHES_THREADS') }}
+  datacite_index_datacite_index_threads: {{ env_var('DATACITE_INDEX_DATACITE_INDEX_THREADS') }}
+  datacite_index_funders_threads: {{ env_var('DATACITE_INDEX_FUNDERS_THREADS') }}
+  datacite_index_institutions_threads: {{ env_var('DATACITE_INDEX_INSTITUTIONS_THREADS') }}
+  datacite_index_updated_dates_threads: {{ env_var('DATACITE_INDEX_UPDATED_DATES_THREADS') }}
+  datacite_index_work_types_threads: {{ env_var('DATACITE_INDEX_WORK_TYPES_THREADS') }}
+  datacite_index_works_threads: {{ env_var('DATACITE_INDEX_WORKS_THREADS') }}
+  openalex_index_abstract_stats_threads: {{ env_var('OPENALEX_INDEX_ABSTRACT_STATS_THREADS') }}
+  openalex_index_abstracts_threads: {{ env_var('OPENALEX_INDEX_ABSTRACTS_THREADS') }}
+  openalex_index_author_names_threads: {{ env_var('OPENALEX_INDEX_AUTHOR_NAMES_THREADS') }}
+  openalex_index_awards_threads: {{ env_var('OPENALEX_INDEX_AWARDS_THREADS') }}
+  openalex_index_funders_threads: {{ env_var('OPENALEX_INDEX_FUNDERS_THREADS') }}
+  openalex_index_openalex_index_hashes_threads: {{ env_var('OPENALEX_INDEX_OPENALEX_INDEX_HASHES_THREADS') }}
+  openalex_index_openalex_index_threads: {{ env_var('OPENALEX_INDEX_OPENALEX_INDEX_THREADS') }}
+  openalex_index_publication_dates_threads: {{ env_var('OPENALEX_INDEX_PUBLICATION_DATES_THREADS') }}
+  openalex_index_title_stats_threads: {{ env_var('OPENALEX_INDEX_TITLE_STATS_THREADS') }}
+  openalex_index_titles_threads: {{ env_var('OPENALEX_INDEX_TITLES_THREADS') }}
+  openalex_index_updated_dates_threads: {{ env_var('OPENALEX_INDEX_UPDATED_DATES_THREADS') }}
+  openalex_index_works_metadata_threads: {{ env_var('OPENALEX_INDEX_WORKS_METADATA_THREADS') }}
+  openalex_openalex_works_threads: {{ env_var('OPENALEX_OPENALEX_WORKS_THREADS') }}
+  opensearch_current_doi_state_threads: {{ env_var('OPENSEARCH_CURRENT_DOI_STATE_THREADS') }}
+  opensearch_export_threads: {{ env_var('OPENSEARCH_EXPORT_THREADS') }}
+  opensearch_next_doi_state_threads: {{ env_var('OPENSEARCH_NEXT_DOI_STATE_THREADS') }}
+  relations_crossref_metadata_degrees_threads: {{ env_var('RELATIONS_CROSSREF_METADATA_DEGREES_THREADS') }}
+  relations_crossref_metadata_threads: {{ env_var('RELATIONS_CROSSREF_METADATA_THREADS') }}
+  relations_data_citation_corpus_threads: {{ env_var('RELATIONS_DATA_CITATION_CORPUS_THREADS') }}
+  relations_datacite_degrees_threads: {{ env_var('RELATIONS_DATACITE_DEGREES_THREADS') }}
+  relations_datacite_threads: {{ env_var('RELATIONS_DATACITE_THREADS') }}
+  relations_relations_index_threads: {{ env_var('RELATIONS_RELATIONS_INDEX_THREADS') }}
+  ror_index_threads: {{ env_var('ROR_INDEX_THREADS') }}
+  ror_ror_threads: {{ env_var('ROR_ROR_THREADS') }}
+  works_index_export_threads: {{ env_var('WORKS_INDEX_EXPORT_THREADS') }}
 
 default_gateway: duckdb
 

--- a/python/dmpworks/sql/models/datacite_index/datacite_index.sql
+++ b/python/dmpworks/sql/models/datacite_index/datacite_index.sql
@@ -9,7 +9,14 @@ MODEL (
   dialect duckdb,
   kind FULL,
   audits (
-    unique_values(columns := (doi))
+    unique_values(columns := (doi)),
+    assert_max_institutions_length(column := institutions, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_authors_length(column := authors, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_funders_length(column := funders, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_awards_length(column := awards, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_intra_work_dois_length(column := relations.intra_work_dois, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_possible_shared_project_dois_length(column := relations.possible_shared_project_dois, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_dataset_citation_dois_length(column := relations.dataset_citation_dois, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false)
   ),
   enabled true
 );

--- a/python/dmpworks/sql/models/openalex_index/openalex_index.sql
+++ b/python/dmpworks/sql/models/openalex_index/openalex_index.sql
@@ -9,7 +9,14 @@ MODEL (
   dialect duckdb,
   kind FULL,
   audits (
-    unique_values(columns := (doi))
+    unique_values(columns := (doi)),
+    assert_max_institutions_length(column := institutions, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_authors_length(column := authors, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_funders_length(column := funders, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_awards_length(column := awards, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_intra_work_dois_length(column := relations.intra_work_dois, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_possible_shared_project_dois_length(column := relations.possible_shared_project_dois, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false),
+    assert_max_dataset_citation_dois_length(column := relations.dataset_citation_dois, threshold := CAST(@VAR('audit_nested_object_limit') AS INT64), blocking := false)
   ),
   enabled true
 );

--- a/python/dmpworks/sql/models/relations/crossref_metadata.sql
+++ b/python/dmpworks/sql/models/relations/crossref_metadata.sql
@@ -39,24 +39,23 @@ PRAGMA threads=CAST(@VAR('relations_crossref_metadata_threads') AS INT64);
 
 WITH relations_with_dois AS (
   SELECT
-    @extract_doi(cm.doi) AS work_doi,
-    @extract_doi(r.relation_id) AS related_doi,
+    work_doi,
+    related_doi,
     CASE
-      WHEN r.relation_type IN ('is-expression-of', 'has-expression', 'is-format-of', 'has-format', 'is-identical-to',
+      WHEN relation_type IN ('is-expression-of', 'has-expression', 'is-format-of', 'has-format', 'is-identical-to',
                              'is-manifestation-of', 'has-manifestation', 'is-manuscript-of', 'has-manuscript',
                              'is-preprint-of', 'has-preprint', 'is-replaced-by', 'replaces', 'is-translation-of',
                              'has-translation', 'is-variant-form-of', 'is-original-form-of', 'is-version-of') THEN TRUE
       ELSE FALSE
     END AS is_intra_work,
     CASE
-      WHEN r.relation_type IN ('is-derived-from', 'has-derivation', 'is-basis-for', 'is-based-on', 'is-supplement-to', 'is-supplemented-by',
+      WHEN relation_type IN ('is-derived-from', 'has-derivation', 'is-basis-for', 'is-based-on', 'is-supplement-to', 'is-supplemented-by',
                              'documents', 'is-documented-by', 'has-part', 'is-part-of', 'continues', 'is-continued-by',
                              'compiles', 'is-compiled-by', 'is-related-material', 'has-related-material') THEN TRUE
       ELSE FALSE
     END AS is_possible_shared_project
-  FROM crossref.crossref_metadata cm, UNNEST(cm.relations) AS item(r)
-  -- Don't filter on id_type = 'DOI', sometimes id_type is not 'doi' but contains DOIs
-  -- hence, we use extract_doi instead and check rd.related_doi IS NOT NULL at the end
+  FROM relations.crossref_metadata_degrees
+  WHERE out_degree <= CAST(@VAR('max_relation_degrees') AS INT64) AND in_degree <= CAST(@VAR('max_relation_degrees') AS INT64)
 ),
 
 bidirectional AS (

--- a/python/dmpworks/sql/models/relations/crossref_metadata_degrees.sql
+++ b/python/dmpworks/sql/models/relations/crossref_metadata_degrees.sql
@@ -1,0 +1,33 @@
+/*
+  relations.crossref_metadata_degrees:
+
+  Counts the number of in and out degrees for each relation type.
+*/
+
+MODEL (
+  name relations.crossref_metadata_degrees,
+  dialect duckdb,
+  kind FULL,
+  enabled true
+);
+
+PRAGMA threads=CAST(@VAR('relations_crossref_metadata_degrees_threads') AS INT64);
+
+
+WITH unnested_relations AS (
+  SELECT
+    cm.doi AS work_doi,
+    r.relation_id AS related_doi,
+    r.relation_type
+  FROM crossref.crossref_metadata cm, UNNEST(cm.relations) AS item(r)
+  WHERE cm.doi IS NOT NULL AND r.relation_id IS NOT NULL AND r.id_type = 'doi' AND cm.doi <> r.relation_id
+  -- DOIs and id_type normalised during transformations so can be relied on here
+)
+
+SELECT
+  work_doi,
+  related_doi,
+  relation_type,
+  COUNT(*) OVER (PARTITION BY work_doi, relation_type) AS out_degree,
+  COUNT(*) OVER (PARTITION BY related_doi, relation_type) AS in_degree
+FROM unnested_relations;

--- a/python/dmpworks/sql/models/relations/data_citation_corpus.sql
+++ b/python/dmpworks/sql/models/relations/data_citation_corpus.sql
@@ -20,20 +20,45 @@ WITH relations_with_dois AS (
   FROM data_citation_corpus.relations r
 ),
 
+unique_pairs AS (
+  SELECT DISTINCT
+    work_doi,
+    dataset_doi
+  FROM relations_with_dois
+  WHERE work_doi IS NOT NULL AND dataset_doi IS NOT NULL AND work_doi <> dataset_doi
+),
+
+pair_degrees AS (
+  SELECT
+    work_doi,
+    dataset_doi,
+    -- The number of datasets this work is connected to
+    COUNT(*) OVER (PARTITION BY work_doi) AS work_degree,
+    -- The number of works this dataset is connected to
+    COUNT(*) OVER (PARTITION BY dataset_doi) AS dataset_degree
+  FROM unique_pairs
+),
+
+filtered_pairs AS (
+  SELECT
+    work_doi,
+    dataset_doi
+  FROM pair_degrees
+  WHERE work_degree <= CAST(@VAR('max_relation_degrees') AS INT64) AND dataset_degree <= CAST(@VAR('max_relation_degrees') AS INT64)
+),
+
 bidirectional AS (
   SELECT
-    rd.work_doi,
-    rd.dataset_doi AS related_doi
-  FROM relations_with_dois rd
-  WHERE rd.work_doi IS NOT NULL AND rd.dataset_doi IS NOT NULL AND rd.work_doi <> rd.dataset_doi
+    work_doi,
+    dataset_doi AS related_doi
+  FROM filtered_pairs
 
   UNION ALL
 
   SELECT
-    rd.dataset_doi AS work_doi,
-    rd.work_doi AS related_doi
-  FROM relations_with_dois rd
-  WHERE rd.work_doi IS NOT NULL AND rd.dataset_doi IS NOT NULL AND rd.work_doi <> rd.dataset_doi
+    dataset_doi AS work_doi,
+    work_doi AS related_doi
+  FROM filtered_pairs
 )
 
 SELECT

--- a/python/dmpworks/sql/models/relations/datacite.sql
+++ b/python/dmpworks/sql/models/relations/datacite.sql
@@ -36,23 +36,22 @@ PRAGMA threads=CAST(@VAR('relations_datacite_threads') AS INT64);
 
 WITH relations_with_dois AS (
   SELECT
-    @extract_doi(dc.doi) AS work_doi,
-    @extract_doi(r.related_identifier) AS related_doi,
+    work_doi,
+    related_doi,
     CASE
-      WHEN r.relation_type IN ('IsIdenticalTo', 'IsObsoletedBy', 'Obsoletes', 'IsPartOf', 'HasPart', 'IsPublishedIn',
+      WHEN relation_type IN ('IsIdenticalTo', 'IsObsoletedBy', 'Obsoletes', 'IsPartOf', 'HasPart', 'IsPublishedIn',
                              'IsTranslationOf', 'HasTranslation', 'IsVariantFormOf', 'IsOriginalFormOf',
                              'HasVersion', 'IsVersionOf', 'IsNewVersionOf', 'IsPreviousVersionOf') THEN TRUE
       ELSE FALSE
     END AS is_intra_work,
     CASE
-      WHEN r.relation_type IN ('Compiles', 'IsCompiledBy', 'Continues', 'IsContinuedBy', 'IsDerivedFrom', 'IsSourceOf',
+      WHEN relation_type IN ('Compiles', 'IsCompiledBy', 'Continues', 'IsContinuedBy', 'IsDerivedFrom', 'IsSourceOf',
                              'Describes', 'IsDescribedBy', 'Documents', 'IsDocumentedBy', 'IsSupplementTo',
                              'IsSupplementedBy') THEN TRUE
       ELSE FALSE
     END AS is_possible_shared_project
-  FROM datacite.datacite dc, UNNEST(dc.relations) AS item(r)
-  -- Don't filter on related_identifier_type = 'DOI', sometimes related_identifier_type is not 'DOI' but contains DOIs
-  -- hence, we use extract_doi instead and check rd.related_doi IS NOT NULL at the end
+  FROM relations.datacite_degrees
+  WHERE out_degree <= CAST(@VAR('max_relation_degrees') AS INT64) AND in_degree <= CAST(@VAR('max_relation_degrees') AS INT64)
 ),
 
 bidirectional AS (

--- a/python/dmpworks/sql/models/relations/datacite_degrees.sql
+++ b/python/dmpworks/sql/models/relations/datacite_degrees.sql
@@ -1,0 +1,32 @@
+/*
+  relations.datacite_degrees:
+
+  Counts the number of in and out degrees for each relation type.
+*/
+
+MODEL (
+  name relations.datacite_degrees,
+  dialect duckdb,
+  kind FULL,
+  enabled true
+);
+
+PRAGMA threads=CAST(@VAR('relations_datacite_degrees_threads') AS INT64);
+
+WITH unnested_relations AS (
+  SELECT
+    dc.doi AS work_doi,
+    r.related_identifier AS related_doi,
+    r.relation_type
+  FROM datacite.datacite dc, UNNEST(dc.relations) AS item(r)
+  WHERE dc.doi IS NOT NULL AND r.related_identifier IS NOT NULL AND r.related_identifier_type = 'DOI' AND dc.doi <> r.related_identifier
+  -- DOIs and related_identifier_type normalised during transformations so can be relied on here
+)
+
+SELECT
+  work_doi,
+  related_doi,
+  relation_type,
+  COUNT(*) OVER (PARTITION BY work_doi, relation_type) AS out_degree,
+  COUNT(*) OVER (PARTITION BY related_doi, relation_type) AS in_degree
+FROM unnested_relations;

--- a/python/dmpworks/sql/tests/relations/test_crossref_metadata.yaml
+++ b/python/dmpworks/sql/tests/relations/test_crossref_metadata.yaml
@@ -1,213 +1,203 @@
 test_relations_crossref_metadata:
   model: relations.crossref_metadata
   inputs:
-    crossref.crossref_metadata:
+    relations.crossref_metadata_degrees:
       rows:
         # intra-work is true
-        - doi: "10.9999/test.0001"
-          relations:
-            - relation_id: "10.1234/test.0001"
-              relation_type: "is-expression-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0002"
-          relations:
-            - relation_id: "10.1234/test.0002"
-              relation_type: "has-expression"
-              id_type: "doi"
-        - doi: "10.9999/test.0003"
-          relations:
-            - relation_id: "10.1234/test.0003"
-              relation_type: "is-expression-of"
-              id_type: "url"
-        - doi: "10.9999/test.0004"
-          relations:
-            - relation_id: "10.1234/test.0004"
-              relation_type: "is-expression-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0005"
-          relations:
-            - relation_id: "10.1234/test.0005"
-              relation_type: "is-format-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0006"
-          relations:
-            - relation_id: "10.1234/test.0006"
-              relation_type: "has-format"
-              id_type: "doi"
-        - doi: "10.9999/test.0007"
-          relations:
-            - relation_id: "10.1234/test.0007"
-              relation_type: "is-identical-to"
-              id_type: "doi"
-        - doi: "10.9999/test.0008"
-          relations:
-            - relation_id: "10.1234/test.0008"
-              relation_type: "is-manifestation-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0009"
-          relations:
-            - relation_id: "10.1234/test.0009"
-              relation_type: "has-manifestation"
-              id_type: "doi"
-        - doi: "10.9999/test.0010"
-          relations:
-            - relation_id: "10.1234/test.0010"
-              relation_type: "is-manuscript-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0011"
-          relations:
-            - relation_id: "10.1234/test.0011"
-              relation_type: "has-manuscript"
-              id_type: "doi"
-        - doi: "10.9999/test.0012"
-          relations:
-            - relation_id: "10.1234/test.0012"
-              relation_type: "is-preprint-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0013"
-          relations:
-            - relation_id: "10.1234/test.0013"
-              relation_type: "has-preprint"
-              id_type: "doi"
-        - doi: "10.9999/test.0014"
-          relations:
-            - relation_id: "10.1234/test.0014"
-              relation_type: "is-replaced-by"
-              id_type: "doi"
-        - doi: "10.9999/test.0015"
-          relations:
-            - relation_id: "10.1234/test.0015"
-              relation_type: "replaces"
-              id_type: "doi"
-        - doi: "10.9999/test.0016"
-          relations:
-            - relation_id: "10.1234/test.0016"
-              relation_type: "is-translation-of"
-              id_type: "url"
-        - doi: "10.9999/test.0017"
-          relations:
-            - relation_id: "10.1234/test.0017"
-              relation_type: "has-translation"
-              id_type: "doi"
-        - doi: "10.9999/test.0018"
-          relations:
-            - relation_id: "10.1234/test.0018"
-              relation_type: "is-variant-form-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0019"
-          relations:
-            - relation_id: "10.1234/test.0019"
-              relation_type: "is-original-form-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0020"
-          relations:
-            - relation_id: "10.1234/test.0020"
-              relation_type: "is-version-of"
-              id_type: "doi"
+        - work_doi: "10.9999/test.0001"
+          related_doi: "10.1234/test.0001"
+          relation_type: "is-expression-of"
+          out_degree: 42
+          in_degree: 12
+        - work_doi: "10.9999/test.0002"
+          related_doi: "10.1234/test.0002"
+          relation_type: "has-expression"
+          out_degree: 88
+          in_degree: 3
+        - work_doi: "10.9999/test.0003"
+          related_doi: "10.1234/test.0003"
+          relation_type: "is-expression-of"
+          out_degree: 25
+          in_degree: 67
+        - work_doi: "10.9999/test.0004"
+          related_doi: "10.1234/test.0004"
+          relation_type: "is-expression-of"
+          out_degree: 99
+          in_degree: 1
+        - work_doi: "10.9999/test.0005"
+          related_doi: "10.1234/test.0005"
+          relation_type: "is-format-of"
+          out_degree: 15
+          in_degree: 75
+        - work_doi: "10.9999/test.0006"
+          related_doi: "10.1234/test.0006"
+          relation_type: "has-format"
+          out_degree: 33
+          in_degree: 33
+        - work_doi: "10.9999/test.0007"
+          related_doi: "10.1234/test.0007"
+          relation_type: "is-identical-to"
+          out_degree: 7
+          in_degree: 92
+        - work_doi: "10.9999/test.0008"
+          related_doi: "10.1234/test.0008"
+          relation_type: "is-manifestation-of"
+          out_degree: 55
+          in_degree: 44
+        - work_doi: "10.9999/test.0009"
+          related_doi: "10.1234/test.0009"
+          relation_type: "has-manifestation"
+          out_degree: 21
+          in_degree: 81
+        - work_doi: "10.9999/test.0010"
+          related_doi: "10.1234/test.0010"
+          relation_type: "is-manuscript-of"
+          out_degree: 60
+          in_degree: 40
+        - work_doi: "10.9999/test.0011"
+          related_doi: "10.1234/test.0011"
+          relation_type: "has-manuscript"
+          out_degree: 11
+          in_degree: 11
+        - work_doi: "10.9999/test.0012"
+          related_doi: "10.1234/test.0012"
+          relation_type: "is-preprint-of"
+          out_degree: 77
+          in_degree: 22
+        - work_doi: "10.9999/test.0013"
+          related_doi: "10.1234/test.0013"
+          relation_type: "has-preprint"
+          out_degree: 36
+          in_degree: 63
+        - work_doi: "10.9999/test.0014"
+          related_doi: "10.1234/test.0014"
+          relation_type: "is-replaced-by"
+          out_degree: 9
+          in_degree: 90
+        - work_doi: "10.9999/test.0015"
+          related_doi: "10.1234/test.0015"
+          relation_type: "replaces"
+          out_degree: 48
+          in_degree: 52
+        - work_doi: "10.9999/test.0016"
+          related_doi: "10.1234/test.0016"
+          relation_type: "is-translation-of"
+          out_degree: 19
+          in_degree: 80
+        - work_doi: "10.9999/test.0017"
+          related_doi: "10.1234/test.0017"
+          relation_type: "has-translation"
+          out_degree: 72
+          in_degree: 27
+        - work_doi: "10.9999/test.0018"
+          related_doi: "10.1234/test.0018"
+          relation_type: "is-variant-form-of"
+          out_degree: 5
+          in_degree: 95
+        - work_doi: "10.9999/test.0019"
+          related_doi: "10.1234/test.0019"
+          relation_type: "is-original-form-of"
+          out_degree: 85
+          in_degree: 14
+        - work_doi: "10.9999/test.0020"
+          related_doi: "10.1234/test.0020"
+          relation_type: "is-version-of"
+          out_degree: 30
+          in_degree: 70
 
         # inter-work
-        - doi: "10.9999/test.0100"
-          relations:
-            - relation_id: "10.1234/test.0100"
-              relation_type: "is-derived-from"
-              id_type: "doi"
-        - doi: "10.9999/test.0101"
-          relations:
-            - relation_id: "10.1234/test.0101"
-              relation_type: "has-derivation"
-              id_type: "doi"
-        - doi: "10.9999/test.0102"
-          relations:
-            - relation_id: "10.1234/test.0102"
-              relation_type: "is-basis-for"
-              id_type: "doi"
-        - doi: "10.9999/test.0103"
-          relations:
-            - relation_id: "10.1234/test.0103"
-              relation_type: "is-based-on"
-              id_type: "url"
-        - doi: "10.9999/test.0104"
-          relations:
-            - relation_id: "10.1234/test.0104"
-              relation_type: "is-supplement-to"
-              id_type: "doi"
-        - doi: "10.9999/test.0105"
-          relations:
-            - relation_id: "10.1234/test.0105"
-              relation_type: "is-supplemented-by"
-              id_type: "doi"
-        - doi: "10.9999/test.0106"
-          relations:
-            - relation_id: "10.1234/test.0106"
-              relation_type: "documents"
-              id_type: "doi"
-        - doi: "10.9999/test.0107"
-          relations:
-            - relation_id: "10.1234/test.0107"
-              relation_type: "is-documented-by"
-              id_type: "doi"
-        - doi: "10.9999/test.0108"
-          relations:
-            - relation_id: "10.1234/test.0108"
-              relation_type: "has-part"
-              id_type: "doi"
-        - doi: "10.9999/test.0109"
-          relations:
-            - relation_id: "10.1234/test.0109"
-              relation_type: "is-part-of"
-              id_type: "doi"
-        - doi: "10.9999/test.0110"
-          relations:
-            - relation_id: "10.1234/test.0110"
-              relation_type: "continues"
-              id_type: "doi"
-        - doi: "10.9999/test.0111"
-          relations:
-            - relation_id: "10.1234/test.0111"
-              relation_type: "is-continued-by"
-              id_type: "doi"
-        - doi: "10.9999/test.0112"
-          relations:
-            - relation_id: "10.1234/test.0112"
-              relation_type: "compiles"
-              id_type: "url"
-        - doi: "10.9999/test.0113"
-          relations:
-            - relation_id: "10.1234/test.0113"
-              relation_type: "is-compiled-by"
-              id_type: "doi"
-        - doi: "10.9999/test.0114"
-          relations:
-            - relation_id: "10.1234/test.0114"
-              relation_type: "is-related-material"
-              id_type: "doi"
-        - doi: "10.9999/test.0115"
-          relations:
-            - relation_id: "10.1234/test.0115"
-              relation_type: "has-related-material"
-              id_type: "doi"
+        - work_doi: "10.9999/test.0100"
+          related_doi: "10.1234/test.0100"
+          relation_type: "is-derived-from"
+          out_degree: 45
+          in_degree: 55
+        - work_doi: "10.9999/test.0101"
+          related_doi: "10.1234/test.0101"
+          relation_type: "has-derivation"
+          out_degree: 65
+          in_degree: 35
+        - work_doi: "10.9999/test.0102"
+          related_doi: "10.1234/test.0102"
+          relation_type: "is-basis-for"
+          out_degree: 20
+          in_degree: 80
+        - work_doi: "10.9999/test.0103"
+          related_doi: "10.1234/test.0103"
+          relation_type: "is-based-on"
+          out_degree: 90
+          in_degree: 10
+        - work_doi: "10.9999/test.0104"
+          related_doi: "10.1234/test.0104"
+          relation_type: "is-supplement-to"
+          out_degree: 10
+          in_degree: 90
+        - work_doi: "10.9999/test.0105"
+          related_doi: "10.1234/test.0105"
+          relation_type: "is-supplemented-by"
+          out_degree: 50
+          in_degree: 50
+        - work_doi: "10.9999/test.0106"
+          related_doi: "10.1234/test.0106"
+          relation_type: "documents"
+          out_degree: 33
+          in_degree: 66
+        - work_doi: "10.9999/test.0107"
+          related_doi: "10.1234/test.0107"
+          relation_type: "is-documented-by"
+          out_degree: 66
+          in_degree: 33
+        - work_doi: "10.9999/test.0108"
+          related_doi: "10.1234/test.0108"
+          relation_type: "has-part"
+          out_degree: 25
+          in_degree: 75
+        - work_doi: "10.9999/test.0109"
+          related_doi: "10.1234/test.0109"
+          relation_type: "is-part-of"
+          out_degree: 75
+          in_degree: 25
+        - work_doi: "10.9999/test.0110"
+          related_doi: "10.1234/test.0110"
+          relation_type: "continues"
+          out_degree: 40
+          in_degree: 60
+        - work_doi: "10.9999/test.0111"
+          related_doi: "10.1234/test.0111"
+          relation_type: "is-continued-by"
+          out_degree: 60
+          in_degree: 40
+        - work_doi: "10.9999/test.0112"
+          related_doi: "10.1234/test.0112"
+          relation_type: "compiles"
+          out_degree: 15
+          in_degree: 85
+        - work_doi: "10.9999/test.0113"
+          related_doi: "10.1234/test.0113"
+          relation_type: "is-compiled-by"
+          out_degree: 85
+          in_degree: 15
+        - work_doi: "10.9999/test.0114"
+          related_doi: "10.1234/test.0114"
+          relation_type: "is-related-material"
+          out_degree: 55
+          in_degree: 45
+        - work_doi: "10.9999/test.0115"
+          related_doi: "10.1234/test.0115"
+          relation_type: "has-related-material"
+          out_degree: 45
+          in_degree: 55
 
-        # others that should be filtered out
-        - doi: "10.9999/test.0200"
-          relations:
-            - relation_id: "10.1234/test.0200"
-              relation_type: "is-cited-by"
-              id_type: "doi"
-        - doi: "10.9999/test.0201"
-          relations:
-            - relation_id: "https://example.org/fulltext/0201"
-              relation_type: "is-expression-of"
-              id_type: "url"
-        - doi: "10.9999/test.0202"
-          relations:
-            - relation_id: "https://example.org/dataset/0202"
-              relation_type: "is-derived-from"
-              id_type: "url"
-        - doi: "10.9999/test.0203"
-          relations:
-            - relation_id: "https://example.org/not-a-doi"
-              relation_type: "is-expression-of"
-              id_type: "doi"
+        # filtered out due to high degree
+        - work_doi: "10.9999/test.0300"
+          related_doi: "10.1234/test.0300"
+          relation_type: "is-expression-of"
+          out_degree: 101
+          in_degree: 50
+        - work_doi: "10.9999/test.0301"
+          related_doi: "10.1234/test.0301"
+          relation_type: "is-expression-of"
+          out_degree: 50
+          in_degree: 101
 
   outputs:
     query:

--- a/python/dmpworks/sql/tests/relations/test_crossref_metadata_degrees.yaml
+++ b/python/dmpworks/sql/tests/relations/test_crossref_metadata_degrees.yaml
@@ -1,0 +1,398 @@
+test_relations_crossref_metadata_degrees:
+  model: relations.crossref_metadata_degrees
+  inputs:
+    crossref.crossref_metadata:
+      rows:
+        # intra-work is true
+        - doi: "10.9999/test.0001"
+          relations:
+            - relation_id: "10.1234/test.0001"
+              relation_type: "is-expression-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0002"
+          relations:
+            - relation_id: "10.1234/test.0002"
+              relation_type: "has-expression"
+              id_type: "doi"
+        - doi: "10.9999/test.0003"
+          relations:
+            - relation_id: "10.1234/test.0003"
+              relation_type: "is-expression-of"
+              id_type: "url"
+        - doi: "10.9999/test.0004"
+          relations:
+            - relation_id: "10.1234/test.0004"
+              relation_type: "is-expression-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0005"
+          relations:
+            - relation_id: "10.1234/test.0005"
+              relation_type: "is-format-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0006"
+          relations:
+            - relation_id: "10.1234/test.0006"
+              relation_type: "has-format"
+              id_type: "doi"
+        - doi: "10.9999/test.0007"
+          relations:
+            - relation_id: "10.1234/test.0007"
+              relation_type: "is-identical-to"
+              id_type: "doi"
+        - doi: "10.9999/test.0008"
+          relations:
+            - relation_id: "10.1234/test.0008"
+              relation_type: "is-manifestation-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0009"
+          relations:
+            - relation_id: "10.1234/test.0009"
+              relation_type: "has-manifestation"
+              id_type: "doi"
+        - doi: "10.9999/test.0010"
+          relations:
+            - relation_id: "10.1234/test.0010"
+              relation_type: "is-manuscript-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0011"
+          relations:
+            - relation_id: "10.1234/test.0011"
+              relation_type: "has-manuscript"
+              id_type: "doi"
+        - doi: "10.9999/test.0012"
+          relations:
+            - relation_id: "10.1234/test.0012"
+              relation_type: "is-preprint-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0013"
+          relations:
+            - relation_id: "10.1234/test.0013"
+              relation_type: "has-preprint"
+              id_type: "doi"
+        - doi: "10.9999/test.0014"
+          relations:
+            - relation_id: "10.1234/test.0014"
+              relation_type: "is-replaced-by"
+              id_type: "doi"
+        - doi: "10.9999/test.0015"
+          relations:
+            - relation_id: "10.1234/test.0015"
+              relation_type: "replaces"
+              id_type: "doi"
+        - doi: "10.9999/test.0016"
+          relations:
+            - relation_id: "10.1234/test.0016"
+              relation_type: "is-translation-of"
+              id_type: "url"
+        - doi: "10.9999/test.0017"
+          relations:
+            - relation_id: "10.1234/test.0017"
+              relation_type: "has-translation"
+              id_type: "doi"
+        - doi: "10.9999/test.0018"
+          relations:
+            - relation_id: "10.1234/test.0018"
+              relation_type: "is-variant-form-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0019"
+          relations:
+            - relation_id: "10.1234/test.0019"
+              relation_type: "is-original-form-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0020"
+          relations:
+            - relation_id: "10.1234/test.0020"
+              relation_type: "is-version-of"
+              id_type: "doi"
+
+        # inter-work
+        - doi: "10.9999/test.0100"
+          relations:
+            - relation_id: "10.1234/test.0100"
+              relation_type: "is-derived-from"
+              id_type: "doi"
+        - doi: "10.9999/test.0101"
+          relations:
+            - relation_id: "10.1234/test.0101"
+              relation_type: "has-derivation"
+              id_type: "doi"
+        - doi: "10.9999/test.0102"
+          relations:
+            - relation_id: "10.1234/test.0102"
+              relation_type: "is-basis-for"
+              id_type: "doi"
+        - doi: "10.9999/test.0103"
+          relations:
+            - relation_id: "10.1234/test.0103"
+              relation_type: "is-based-on"
+              id_type: "url"
+        - doi: "10.9999/test.0104"
+          relations:
+            - relation_id: "10.1234/test.0104"
+              relation_type: "is-supplement-to"
+              id_type: "doi"
+        - doi: "10.9999/test.0105"
+          relations:
+            - relation_id: "10.1234/test.0105"
+              relation_type: "is-supplemented-by"
+              id_type: "doi"
+        - doi: "10.9999/test.0106"
+          relations:
+            - relation_id: "10.1234/test.0106"
+              relation_type: "documents"
+              id_type: "doi"
+        - doi: "10.9999/test.0107"
+          relations:
+            - relation_id: "10.1234/test.0107"
+              relation_type: "is-documented-by"
+              id_type: "doi"
+        - doi: "10.9999/test.0108"
+          relations:
+            - relation_id: "10.1234/test.0108"
+              relation_type: "has-part"
+              id_type: "doi"
+        - doi: "10.9999/test.0109"
+          relations:
+            - relation_id: "10.1234/test.0109"
+              relation_type: "is-part-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0110"
+          relations:
+            - relation_id: "10.1234/test.0110"
+              relation_type: "continues"
+              id_type: "doi"
+        - doi: "10.9999/test.0111"
+          relations:
+            - relation_id: "10.1234/test.0111"
+              relation_type: "is-continued-by"
+              id_type: "doi"
+        - doi: "10.9999/test.0112"
+          relations:
+            - relation_id: "10.1234/test.0112"
+              relation_type: "compiles"
+              id_type: "url"
+        - doi: "10.9999/test.0113"
+          relations:
+            - relation_id: "10.1234/test.0113"
+              relation_type: "is-compiled-by"
+              id_type: "doi"
+        - doi: "10.9999/test.0114"
+          relations:
+            - relation_id: "10.1234/test.0114"
+              relation_type: "is-related-material"
+              id_type: "doi"
+        - doi: "10.9999/test.0115"
+          relations:
+            - relation_id: "10.1234/test.0115"
+              relation_type: "has-related-material"
+              id_type: "doi"
+
+        - doi: "10.9999/test.0200"
+          relations:
+            - relation_id: "10.1234/test.0200"
+              relation_type: "is-cited-by"
+              id_type: "doi"
+
+        # High degree test cases
+        - doi: "10.9999/test.0300"
+          relations:
+            - relation_id: "10.1234/test.0300"
+              relation_type: "is-expression-of"
+              id_type: "doi"
+            - relation_id: "10.1234/test.0301"
+              relation_type: "is-expression-of"
+              id_type: "doi"
+        - doi: "10.9999/test.0301"
+          relations:
+            - relation_id: "10.1234/test.0300"
+              relation_type: "is-expression-of"
+              id_type: "doi"
+
+  outputs:
+    query:
+      rows:
+        - work_doi: "10.9999/test.0001"
+          related_doi: "10.1234/test.0001"
+          relation_type: "is-expression-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0002"
+          related_doi: "10.1234/test.0002"
+          relation_type: "has-expression"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0004"
+          related_doi: "10.1234/test.0004"
+          relation_type: "is-expression-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0005"
+          related_doi: "10.1234/test.0005"
+          relation_type: "is-format-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0006"
+          related_doi: "10.1234/test.0006"
+          relation_type: "has-format"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0007"
+          related_doi: "10.1234/test.0007"
+          relation_type: "is-identical-to"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0008"
+          related_doi: "10.1234/test.0008"
+          relation_type: "is-manifestation-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0009"
+          related_doi: "10.1234/test.0009"
+          relation_type: "has-manifestation"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0010"
+          related_doi: "10.1234/test.0010"
+          relation_type: "is-manuscript-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0011"
+          related_doi: "10.1234/test.0011"
+          relation_type: "has-manuscript"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0012"
+          related_doi: "10.1234/test.0012"
+          relation_type: "is-preprint-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0013"
+          related_doi: "10.1234/test.0013"
+          relation_type: "has-preprint"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0014"
+          related_doi: "10.1234/test.0014"
+          relation_type: "is-replaced-by"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0015"
+          related_doi: "10.1234/test.0015"
+          relation_type: "replaces"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0017"
+          related_doi: "10.1234/test.0017"
+          relation_type: "has-translation"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0018"
+          related_doi: "10.1234/test.0018"
+          relation_type: "is-variant-form-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0019"
+          related_doi: "10.1234/test.0019"
+          relation_type: "is-original-form-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0020"
+          related_doi: "10.1234/test.0020"
+          relation_type: "is-version-of"
+          out_degree: 1
+          in_degree: 1
+
+        # inter-work
+        - work_doi: "10.9999/test.0100"
+          related_doi: "10.1234/test.0100"
+          relation_type: "is-derived-from"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0101"
+          related_doi: "10.1234/test.0101"
+          relation_type: "has-derivation"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0102"
+          related_doi: "10.1234/test.0102"
+          relation_type: "is-basis-for"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0104"
+          related_doi: "10.1234/test.0104"
+          relation_type: "is-supplement-to"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0105"
+          related_doi: "10.1234/test.0105"
+          relation_type: "is-supplemented-by"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0106"
+          related_doi: "10.1234/test.0106"
+          relation_type: "documents"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0107"
+          related_doi: "10.1234/test.0107"
+          relation_type: "is-documented-by"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0108"
+          related_doi: "10.1234/test.0108"
+          relation_type: "has-part"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0109"
+          related_doi: "10.1234/test.0109"
+          relation_type: "is-part-of"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0110"
+          related_doi: "10.1234/test.0110"
+          relation_type: "continues"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0111"
+          related_doi: "10.1234/test.0111"
+          relation_type: "is-continued-by"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0113"
+          related_doi: "10.1234/test.0113"
+          relation_type: "is-compiled-by"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0114"
+          related_doi: "10.1234/test.0114"
+          relation_type: "is-related-material"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0115"
+          related_doi: "10.1234/test.0115"
+          relation_type: "has-related-material"
+          out_degree: 1
+          in_degree: 1
+
+        - work_doi: "10.9999/test.0200"
+          related_doi: "10.1234/test.0200"
+          relation_type: "is-cited-by"
+          out_degree: 1
+          in_degree: 1
+
+        # Higher degree test cases
+        - work_doi: "10.9999/test.0300"
+          related_doi: "10.1234/test.0300"
+          relation_type: "is-expression-of"
+          out_degree: 2
+          in_degree: 2
+        - work_doi: "10.9999/test.0300"
+          related_doi: "10.1234/test.0301"
+          relation_type: "is-expression-of"
+          out_degree: 2
+          in_degree: 1
+        - work_doi: "10.9999/test.0301"
+          related_doi: "10.1234/test.0300"
+          relation_type: "is-expression-of"
+          out_degree: 1
+          in_degree: 2

--- a/python/dmpworks/sql/tests/relations/test_data_citation_corpus.yaml
+++ b/python/dmpworks/sql/tests/relations/test_data_citation_corpus.yaml
@@ -1,5 +1,7 @@
 test_relations_data_citation_corpus:
   model: relations.data_citation_corpus
+  vars:
+    max_relation_degrees: 3
   inputs:
     data_citation_corpus.relations:
       rows:
@@ -14,6 +16,20 @@ test_relations_data_citation_corpus:
           source: datacite
         - publication: "https://doi.org/10.9999/test.0004"
           dataset: "https://doi.org/10.1234/test.0004"
+          source: eupmc
+
+        # Higher degree test cases: should be filtered out
+        - publication: "https://doi.org/10.9999/test.0005"
+          dataset: "https://doi.org/10.1234/test.0005"
+          source: eupmc
+        - publication: "https://doi.org/10.9999/test.0005"
+          dataset: "https://doi.org/10.1234/test.0006"
+          source: eupmc
+        - publication: "https://doi.org/10.9999/test.0005"
+          dataset: "https://doi.org/10.1234/test.0007"
+          source: eupmc
+        - publication: "https://doi.org/10.9999/test.0005"
+          dataset: "https://doi.org/10.1234/test.0008"
           source: eupmc
 
   outputs:

--- a/python/dmpworks/sql/tests/relations/test_datacite.yaml
+++ b/python/dmpworks/sql/tests/relations/test_datacite.yaml
@@ -1,323 +1,324 @@
 test_relations_datacite:
   model: relations.datacite
   inputs:
-    datacite.datacite:
+    relations.datacite_degrees:
       rows:
         # intra-work is true
-        - doi: "10.9999/test.0001"
-          relations:
-            - related_identifier: "10.1234/test.0001"
-              relation_type: "IsIdenticalTo"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0002"
-          relations:
-            - related_identifier: "10.1234/test.0002"
-              relation_type: "IsObsoletedBy"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0003"
-          relations:
-            - related_identifier: "10.1234/test.0003"
-              relation_type: "Obsoletes"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0004"
-          relations:
-            - related_identifier: "10.1234/test.0004"
-              relation_type: "IsPartOf"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0005"
-          relations:
-            - related_identifier: "10.1234/test.0005"
-              relation_type: "HasPart"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0006"
-          relations:
-            - related_identifier: "10.1234/test.0006"
-              relation_type: "IsPublishedIn"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0007"
-          relations:
-            - related_identifier: "10.1234/test.0007"
-              relation_type: "IsTranslationOf"
-              related_identifier_type: "URL"
-        - doi: "10.9999/test.0008"
-          relations:
-            - related_identifier: "10.1234/test.0008"
-              relation_type: "HasTranslation"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0009"
-          relations:
-            - related_identifier: "10.1234/test.0009"
-              relation_type: "IsVariantFormOf"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0010"
-          relations:
-            - related_identifier: "10.1234/test.0010"
-              relation_type: "IsOriginalFormOf"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0011"
-          relations:
-            - related_identifier: "10.1234/test.0011"
-              relation_type: "HasVersion"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0012"
-          relations:
-            - related_identifier: "10.1234/test.0012"
-              relation_type: "IsVersionOf"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0013"
-          relations:
-            - related_identifier: "10.1234/test.0013"
-              relation_type: "IsNewVersionOf"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0014"
-          relations:
-            - related_identifier: "10.1234/test.0014"
-              relation_type: "IsPreviousVersionOf"
-              related_identifier_type: "DOI"
+        - work_doi: "10.9999/test.0001"
+          related_doi: "10.1234/test.0001"
+          relation_type: "IsIdenticalTo"
+          out_degree: 42
+          in_degree: 12
+        - work_doi: "10.9999/test.0002"
+          related_doi: "10.1234/test.0002"
+          relation_type: "IsObsoletedBy"
+          out_degree: 88
+          in_degree: 3
+        - work_doi: "10.9999/test.0003"
+          related_doi: "10.1234/test.0003"
+          relation_type: "Obsoletes"
+          out_degree: 25
+          in_degree: 67
+        - work_doi: "10.9999/test.0004"
+          related_doi: "10.1234/test.0004"
+          relation_type: "IsPartOf"
+          out_degree: 99
+          in_degree: 1
+        - work_doi: "10.9999/test.0005"
+          related_doi: "10.1234/test.0005"
+          relation_type: "HasPart"
+          out_degree: 15
+          in_degree: 75
+        - work_doi: "10.9999/test.0006"
+          related_doi: "10.1234/test.0006"
+          relation_type: "IsPublishedIn"
+          out_degree: 33
+          in_degree: 33
+        - work_doi: "10.9999/test.0007"
+          related_doi: "10.1234/test.0007"
+          relation_type: "IsTranslationOf"
+          out_degree: 7
+          in_degree: 92
+        - work_doi: "10.9999/test.0008"
+          related_doi: "10.1234/test.0008"
+          relation_type: "HasTranslation"
+          out_degree: 55
+          in_degree: 44
+        - work_doi: "10.9999/test.0009"
+          related_doi: "10.1234/test.0009"
+          relation_type: "IsVariantFormOf"
+          out_degree: 21
+          in_degree: 81
+        - work_doi: "10.9999/test.0010"
+          related_doi: "10.1234/test.0010"
+          relation_type: "IsOriginalFormOf"
+          out_degree: 60
+          in_degree: 40
+        - work_doi: "10.9999/test.0011"
+          related_doi: "10.1234/test.0011"
+          relation_type: "HasVersion"
+          out_degree: 11
+          in_degree: 11
+        - work_doi: "10.9999/test.0012"
+          related_doi: "10.1234/test.0012"
+          relation_type: "IsVersionOf"
+          out_degree: 77
+          in_degree: 22
+        - work_doi: "10.9999/test.0013"
+          related_doi: "10.1234/test.0013"
+          relation_type: "IsNewVersionOf"
+          out_degree: 36
+          in_degree: 63
+        - work_doi: "10.9999/test.0014"
+          related_doi: "10.1234/test.0014"
+          relation_type: "IsPreviousVersionOf"
+          out_degree: 9
+          in_degree: 90
 
         # is_possible_shared_project is true
-        - doi: "10.9999/test.0100"
-          relations:
-            - related_identifier: "10.1234/test.0100"
-              relation_type: "Compiles"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0101"
-          relations:
-            - related_identifier: "10.1234/test.0101"
-              relation_type: "IsCompiledBy"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0102"
-          relations:
-            - related_identifier: "10.1234/test.0102"
-              relation_type: "Continues"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0103"
-          relations:
-            - related_identifier: "10.1234/test.0103"
-              relation_type: "IsContinuedBy"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0104"
-          relations:
-            - related_identifier: "10.1234/test.0104"
-              relation_type: "IsDerivedFrom"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0105"
-          relations:
-            - related_identifier: "10.1234/test.0105"
-              relation_type: "IsSourceOf"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0106"
-          relations:
-            - related_identifier: "10.1234/test.0106"
-              relation_type: "Describes"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0107"
-          relations:
-            - related_identifier: "10.1234/test.0107"
-              relation_type: "IsDescribedBy"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0108"
-          relations:
-            - related_identifier: "10.1234/test.0108"
-              relation_type: "Documents"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0109"
-          relations:
-            - related_identifier: "10.1234/test.0109"
-              relation_type: "IsDocumentedBy"
-              related_identifier_type: "URL"
-        - doi: "10.9999/test.0110"
-          relations:
-            - related_identifier: "10.1234/test.0110"
-              relation_type: "IsSupplementTo"
-              related_identifier_type: "DOI"
-        - doi: "10.9999/test.0111"
-          relations:
-            - related_identifier: "10.1234/test.0111"
-              relation_type: "IsSupplementedBy"
-              related_identifier_type: "DOI"
+        - work_doi: "10.9999/test.0100"
+          related_doi: "10.1234/test.0100"
+          relation_type: "Compiles"
+          out_degree: 48
+          in_degree: 52
+        - work_doi: "10.9999/test.0101"
+          related_doi: "10.1234/test.0101"
+          relation_type: "IsCompiledBy"
+
+          out_degree: 19
+          in_degree: 80
+        - work_doi: "10.9999/test.0102"
+          related_doi: "10.1234/test.0102"
+          relation_type: "Continues"
+          out_degree: 72
+          in_degree: 27
+        - work_doi: "10.9999/test.0103"
+          related_doi: "10.1234/test.0103"
+          relation_type: "IsContinuedBy"
+          out_degree: 5
+          in_degree: 95
+        - work_doi: "10.9999/test.0104"
+          related_doi: "10.1234/test.0104"
+          relation_type: "IsDerivedFrom"
+          out_degree: 85
+          in_degree: 14
+        - work_doi: "10.9999/test.0105"
+          related_doi: "10.1234/test.0105"
+          relation_type: "IsSourceOf"
+          out_degree: 30
+          in_degree: 70
+        - work_doi: "10.9999/test.0106"
+          related_doi: "10.1234/test.0106"
+          relation_type: "Describes"
+          out_degree: 45
+          in_degree: 55
+        - work_doi: "10.9999/test.0107"
+          related_doi: "10.1234/test.0107"
+          relation_type: "IsDescribedBy"
+          out_degree: 65
+          in_degree: 35
+        - work_doi: "10.9999/test.0108"
+          related_doi: "10.1234/test.0108"
+          relation_type: "Documents"
+          out_degree: 20
+          in_degree: 80
+        - work_doi: "10.9999/test.0109"
+          related_doi: "10.1234/test.0109"
+          relation_type: "IsDocumentedBy"
+          out_degree: 90
+          in_degree: 10
+        - work_doi: "10.9999/test.0110"
+          related_doi: "10.1234/test.0110"
+          relation_type: "IsSupplementTo"
+          out_degree: 10
+          in_degree: 90
+        - work_doi: "10.9999/test.0111"
+          related_doi: "10.1234/test.0111"
+          relation_type: "IsSupplementedBy"
+          out_degree: 50
+          in_degree: 50
 
         # Types not included will still be present
-        - doi: "10.9999/test.0200"
-          relations:
-            - related_identifier: "10.1234/test.0200"
-              relation_type: "IsCitedBy"
-              related_identifier_type: "DOI"
+        - work_doi: "10.9999/test.0200"
+          related_doi: "10.1234/test.0200"
+          relation_type: "IsCitedBy"
+          out_degree: 33
+          in_degree: 66
 
-        # Works without DOIs won't be present
-        - doi: "10.9999/test.0201"
-          relations:
-            - related_identifier: "https://example.org/fulltext/0201"
-              relation_type: "IsIdenticalTo"
-              related_identifier_type: "URL"
-        - doi: "10.9999/test.0202"
-          relations:
-            - related_identifier: "https://example.org/dataset/0202"
-              relation_type: "IsDerivedFrom"
-              related_identifier_type: "URL"
+        # filtered out due to high degree
+        - work_doi: "10.9999/test.0300"
+          related_doi: "10.1234/test.0300"
+          relation_type: "IsIdenticalTo"
+          out_degree: 101
+          in_degree: 50
+        - work_doi: "10.9999/test.0301"
+          related_doi: "10.1234/test.0301"
+          relation_type: "IsIdenticalTo"
+          out_degree: 50
+          in_degree: 101
 
   outputs:
     query:
       rows:
         # is_intra_work true
         - doi: "10.9999/test.0001"
-          intra_work_dois: ["10.1234/test.0001"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0001" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0001"
-          intra_work_dois: ["10.9999/test.0001"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0001" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0002"
-          intra_work_dois: ["10.1234/test.0002"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0002" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0002"
-          intra_work_dois: ["10.9999/test.0002"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0002" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0003"
-          intra_work_dois: ["10.1234/test.0003"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0003" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0003"
-          intra_work_dois: ["10.9999/test.0003"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0003" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0004"
-          intra_work_dois: ["10.1234/test.0004"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0004" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0004"
-          intra_work_dois: ["10.9999/test.0004"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0004" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0005"
-          intra_work_dois: ["10.1234/test.0005"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0005" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0005"
-          intra_work_dois: ["10.9999/test.0005"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0005" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0006"
-          intra_work_dois: ["10.1234/test.0006"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0006" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0006"
-          intra_work_dois: ["10.9999/test.0006"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0006" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0007"
-          intra_work_dois: ["10.1234/test.0007"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0007" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0007"
-          intra_work_dois: ["10.9999/test.0007"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0007" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0008"
-          intra_work_dois: ["10.1234/test.0008"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0008" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0008"
-          intra_work_dois: ["10.9999/test.0008"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0008" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0009"
-          intra_work_dois: ["10.1234/test.0009"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0009" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0009"
-          intra_work_dois: ["10.9999/test.0009"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0009" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0010"
-          intra_work_dois: ["10.1234/test.0010"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0010" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0010"
-          intra_work_dois: ["10.9999/test.0010"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0010" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0011"
-          intra_work_dois: ["10.1234/test.0011"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0011" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0011"
-          intra_work_dois: ["10.9999/test.0011"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0011" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0012"
-          intra_work_dois: ["10.1234/test.0012"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0012" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0012"
-          intra_work_dois: ["10.9999/test.0012"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0012" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0013"
-          intra_work_dois: ["10.1234/test.0013"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0013" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0013"
-          intra_work_dois: ["10.9999/test.0013"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0013" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.9999/test.0014"
-          intra_work_dois: ["10.1234/test.0014"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.1234/test.0014" ]
+          possible_shared_project_dois: [ ]
         - doi: "10.1234/test.0014"
-          intra_work_dois: ["10.9999/test.0014"]
-          possible_shared_project_dois: []
+          intra_work_dois: [ "10.9999/test.0014" ]
+          possible_shared_project_dois: [ ]
 
         # is_possible_shared_project true
         - doi: "10.9999/test.0100"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0100"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0100" ]
         - doi: "10.1234/test.0100"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0100"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0100" ]
         - doi: "10.9999/test.0101"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0101"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0101" ]
         - doi: "10.1234/test.0101"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0101"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0101" ]
         - doi: "10.9999/test.0102"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0102"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0102" ]
         - doi: "10.1234/test.0102"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0102"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0102" ]
         - doi: "10.9999/test.0103"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0103"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0103" ]
         - doi: "10.1234/test.0103"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0103"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0103" ]
         - doi: "10.9999/test.0104"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0104"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0104" ]
         - doi: "10.1234/test.0104"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0104"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0104" ]
         - doi: "10.9999/test.0105"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0105"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0105" ]
         - doi: "10.1234/test.0105"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0105"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0105" ]
         - doi: "10.9999/test.0106"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0106"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0106" ]
         - doi: "10.1234/test.0106"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0106"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0106" ]
         - doi: "10.9999/test.0107"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0107"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0107" ]
         - doi: "10.1234/test.0107"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0107"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0107" ]
         - doi: "10.9999/test.0108"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0108"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0108" ]
         - doi: "10.1234/test.0108"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0108"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0108" ]
         - doi: "10.9999/test.0109"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0109"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0109" ]
         - doi: "10.1234/test.0109"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0109"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0109" ]
         - doi: "10.9999/test.0110"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0110"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0110" ]
         - doi: "10.1234/test.0110"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0110"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0110" ]
         - doi: "10.9999/test.0111"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.1234/test.0111"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.1234/test.0111" ]
         - doi: "10.1234/test.0111"
-          intra_work_dois: []
-          possible_shared_project_dois: ["10.9999/test.0111"]
+          intra_work_dois: [ ]
+          possible_shared_project_dois: [ "10.9999/test.0111" ]
 
         # neither flag set (still present)
 #        - doi: "10.9999/test.0200"

--- a/python/dmpworks/sql/tests/relations/test_datacite_degrees.yaml
+++ b/python/dmpworks/sql/tests/relations/test_datacite_degrees.yaml
@@ -1,0 +1,322 @@
+test_relations_datacite_degrees:
+  model: relations.datacite_degrees
+  inputs:
+    datacite.datacite:
+      rows:
+        # intra-work is true
+        - doi: "10.9999/test.0001"
+          relations:
+            - related_identifier: "10.1234/test.0001"
+              relation_type: "IsIdenticalTo"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0002"
+          relations:
+            - related_identifier: "10.1234/test.0002"
+              relation_type: "IsObsoletedBy"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0003"
+          relations:
+            - related_identifier: "10.1234/test.0003"
+              relation_type: "Obsoletes"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0004"
+          relations:
+            - related_identifier: "10.1234/test.0004"
+              relation_type: "IsPartOf"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0005"
+          relations:
+            - related_identifier: "10.1234/test.0005"
+              relation_type: "HasPart"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0006"
+          relations:
+            - related_identifier: "10.1234/test.0006"
+              relation_type: "IsPublishedIn"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0007"
+          relations:
+            - related_identifier: "10.1234/test.0007"
+              relation_type: "IsTranslationOf"
+              related_identifier_type: "URL"
+        - doi: "10.9999/test.0008"
+          relations:
+            - related_identifier: "10.1234/test.0008"
+              relation_type: "HasTranslation"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0009"
+          relations:
+            - related_identifier: "10.1234/test.0009"
+              relation_type: "IsVariantFormOf"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0010"
+          relations:
+            - related_identifier: "10.1234/test.0010"
+              relation_type: "IsOriginalFormOf"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0011"
+          relations:
+            - related_identifier: "10.1234/test.0011"
+              relation_type: "HasVersion"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0012"
+          relations:
+            - related_identifier: "10.1234/test.0012"
+              relation_type: "IsVersionOf"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0013"
+          relations:
+            - related_identifier: "10.1234/test.0013"
+              relation_type: "IsNewVersionOf"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0014"
+          relations:
+            - related_identifier: "10.1234/test.0014"
+              relation_type: "IsPreviousVersionOf"
+              related_identifier_type: "DOI"
+
+        # is_possible_shared_project is true
+        - doi: "10.9999/test.0100"
+          relations:
+            - related_identifier: "10.1234/test.0100"
+              relation_type: "Compiles"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0101"
+          relations:
+            - related_identifier: "10.1234/test.0101"
+              relation_type: "IsCompiledBy"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0102"
+          relations:
+            - related_identifier: "10.1234/test.0102"
+              relation_type: "Continues"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0103"
+          relations:
+            - related_identifier: "10.1234/test.0103"
+              relation_type: "IsContinuedBy"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0104"
+          relations:
+            - related_identifier: "10.1234/test.0104"
+              relation_type: "IsDerivedFrom"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0105"
+          relations:
+            - related_identifier: "10.1234/test.0105"
+              relation_type: "IsSourceOf"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0106"
+          relations:
+            - related_identifier: "10.1234/test.0106"
+              relation_type: "Describes"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0107"
+          relations:
+            - related_identifier: "10.1234/test.0107"
+              relation_type: "IsDescribedBy"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0108"
+          relations:
+            - related_identifier: "10.1234/test.0108"
+              relation_type: "Documents"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0109"
+          relations:
+            - related_identifier: "10.1234/test.0109"
+              relation_type: "IsDocumentedBy"
+              related_identifier_type: "URL"
+        - doi: "10.9999/test.0110"
+          relations:
+            - related_identifier: "10.1234/test.0110"
+              relation_type: "IsSupplementTo"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0111"
+          relations:
+            - related_identifier: "10.1234/test.0111"
+              relation_type: "IsSupplementedBy"
+              related_identifier_type: "DOI"
+
+        # Types not included will still be present
+        - doi: "10.9999/test.0200"
+          relations:
+            - related_identifier: "10.1234/test.0200"
+              relation_type: "IsCitedBy"
+              related_identifier_type: "DOI"
+
+        # Works without DOIs won't be present
+        - doi: "10.9999/test.0201"
+          relations:
+            - related_identifier: "https://example.org/fulltext/0201"
+              relation_type: "IsIdenticalTo"
+              related_identifier_type: "URL"
+        - doi: "10.9999/test.0202"
+          relations:
+            - related_identifier: "https://example.org/dataset/0202"
+              relation_type: "IsDerivedFrom"
+              related_identifier_type: "URL"
+
+        # High degree test cases
+        - doi: "10.9999/test.0300"
+          relations:
+            - related_identifier: "10.1234/test.0300"
+              relation_type: "IsIdenticalTo"
+              related_identifier_type: "DOI"
+            - related_identifier: "10.1234/test.0301"
+              relation_type: "IsIdenticalTo"
+              related_identifier_type: "DOI"
+        - doi: "10.9999/test.0301"
+          relations:
+            - related_identifier: "10.1234/test.0300"
+              relation_type: "IsIdenticalTo"
+              related_identifier_type: "DOI"
+
+  outputs:
+    query:
+      rows:
+        - work_doi: "10.9999/test.0001"
+          related_doi: "10.1234/test.0001"
+          relation_type: "IsIdenticalTo"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0002"
+          related_doi: "10.1234/test.0002"
+          relation_type: "IsObsoletedBy"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0003"
+          related_doi: "10.1234/test.0003"
+          relation_type: "Obsoletes"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0004"
+          related_doi: "10.1234/test.0004"
+          relation_type: "IsPartOf"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0005"
+          related_doi: "10.1234/test.0005"
+          relation_type: "HasPart"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0006"
+          related_doi: "10.1234/test.0006"
+          relation_type: "IsPublishedIn"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0008"
+          related_doi: "10.1234/test.0008"
+          relation_type: "HasTranslation"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0009"
+          related_doi: "10.1234/test.0009"
+          relation_type: "IsVariantFormOf"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0010"
+          related_doi: "10.1234/test.0010"
+          relation_type: "IsOriginalFormOf"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0011"
+          related_doi: "10.1234/test.0011"
+          relation_type: "HasVersion"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0012"
+          related_doi: "10.1234/test.0012"
+          relation_type: "IsVersionOf"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0013"
+          related_doi: "10.1234/test.0013"
+          relation_type: "IsNewVersionOf"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0014"
+          related_doi: "10.1234/test.0014"
+          relation_type: "IsPreviousVersionOf"
+          out_degree: 1
+          in_degree: 1
+
+        # is_possible_shared_project is true
+        - work_doi: "10.9999/test.0100"
+          related_doi: "10.1234/test.0100"
+          relation_type: "Compiles"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0101"
+          related_doi: "10.1234/test.0101"
+          relation_type: "IsCompiledBy"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0102"
+          related_doi: "10.1234/test.0102"
+          relation_type: "Continues"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0103"
+          related_doi: "10.1234/test.0103"
+          relation_type: "IsContinuedBy"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0104"
+          related_doi: "10.1234/test.0104"
+          relation_type: "IsDerivedFrom"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0105"
+          related_doi: "10.1234/test.0105"
+          relation_type: "IsSourceOf"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0106"
+          related_doi: "10.1234/test.0106"
+          relation_type: "Describes"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0107"
+          related_doi: "10.1234/test.0107"
+          relation_type: "IsDescribedBy"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0108"
+          related_doi: "10.1234/test.0108"
+          relation_type: "Documents"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0110"
+          related_doi: "10.1234/test.0110"
+          relation_type: "IsSupplementTo"
+          out_degree: 1
+          in_degree: 1
+        - work_doi: "10.9999/test.0111"
+          related_doi: "10.1234/test.0111"
+          relation_type: "IsSupplementedBy"
+          out_degree: 1
+          in_degree: 1
+
+        # Types not included will still be present
+        - work_doi: "10.9999/test.0200"
+          related_doi: "10.1234/test.0200"
+          relation_type: "IsCitedBy"
+          out_degree: 1
+          in_degree: 1
+
+        # High degree test cases
+        - work_doi: "10.9999/test.0300"
+          related_doi: "10.1234/test.0300"
+          relation_type: "IsIdenticalTo"
+          out_degree: 2
+          in_degree: 2
+        - work_doi: "10.9999/test.0300"
+          related_doi: "10.1234/test.0301"
+          relation_type: "IsIdenticalTo"
+          out_degree: 2
+          in_degree: 1
+        - work_doi: "10.9999/test.0301"
+          related_doi: "10.1234/test.0300"
+          relation_type: "IsIdenticalTo"
+          out_degree: 1
+          in_degree: 2

--- a/python/dmpworks/transform/crossref_metadata.py
+++ b/python/dmpworks/transform/crossref_metadata.py
@@ -172,9 +172,19 @@ def parse_relations(relation_obj: simdjson.Object) -> list[dict]:
 
     for relation_type, sub_relation_array in relation_obj.items():
         for obj in sub_relation_array:
-            relation_id = normalise_identifier(obj.get("id"))
+            relation_id = to_optional_string(obj.get("id"))
             id_type = to_optional_string(obj.get("id-type"))
             asserted_by = to_optional_string(obj.get("asserted-by"))
+
+            # Remove url prefix from DOIs
+            doi = extract_doi(relation_id)
+            if doi is not None:
+                relation_id = doi
+                id_type = "doi"
+            else:
+                relation_id = normalise_identifier(relation_id)
+                if id_type == "doi":
+                    id_type = None
 
             if any([relation_type, relation_id, id_type, asserted_by]):
                 relations.append(

--- a/python/dmpworks/transform/datacite.py
+++ b/python/dmpworks/transform/datacite.py
@@ -27,8 +27,8 @@ DATACITE_SCHEMA = pa.schema(
         pa.field("title", pa.string(), nullable=True),
         pa.field("abstract", pa.string(), nullable=True),
         pa.field("work_type", pa.string(), nullable=True),
-        pa.field("publication_date", pa.date32(), nullable=True),  # TODO CHECK
-        pa.field("updated_date", pa.timestamp("us"), nullable=True),  # TODO CHECK
+        pa.field("publication_date", pa.date32(), nullable=True),
+        pa.field("updated_date", pa.timestamp("us"), nullable=True),
         pa.field("publication_venue", pa.string(), nullable=True),
         pa.field(
             "authors",
@@ -311,6 +311,8 @@ def parse_relations(related_identifier_array: simdjson.Array | list[simdjson.Obj
             related_identifier_type = "DOI"
         else:
             related_identifier = normalise_identifier(related_identifier)
+            if related_identifier_type == "DOI":
+                related_identifier_type = None
 
         if any([relation_type, related_identifier, related_identifier_type]):
             relations.append(


### PR DESCRIPTION
Filters out relations (work doi, related doi, relation type) where a work has more than 100 other items connecting to it under a specific relation type. Also added  audits to all of the array columns to check if they have gone over a certain length. For example, to check that they are below the maximum number of nested objects allowed in OpenSearch. Both values are configurable via an environment variable.