### PR TITLE
Enable subsetting of DMPs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -30,16 +30,28 @@ UPSTREAM_ROR=/path/to/upstream/ror
 UPSTREAM_DATA_CITATION_CORPUS=/path/to/upstream/data_citation_corpus
 
 ########################################################################
-# Dataset Subsets
+# Dataset Subset (Works)
 ########################################################################
+# Enable subset creation to filter works by specific institutions or a list of DOIs.
+DATASET_SUBSET_ENABLE=false
 # Path to a JSON file containing a list of ROR IDs and institution names,
 # e.g. [{"name": "University of California, San Diego", "ror": "0168r3w48"}]
 # Works authored by researchers from these institutions will be included.
 DATASET_SUBSET_INSTITUTIONS_PATH=${DATA_DIR}/meta/institutions.json
-
 # Path to a JSON file with specific list of Work DOIs to include in the subset,
 # e.g. ["10.0000/abc", "10.0000/123"]
 DATASET_SUBSET_DOIS_PATH=${DATA_DIR}/meta/work_dois.json
+
+########################################################################
+# Dataset Subset (DMPs)
+########################################################################
+# Enable subset creation to filter DMPs by specific institutions or a list of DOIs.
+DMP_SUBSET_ENABLE=false
+# Path to a JSON file containing ROR IDs and institution names.
+# DMPs created by researchers from these institutions will be included.
+DMP_SUBSET_INSTITUTIONS_PATH=${DATA_DIR}/meta/dmp_institutions.json
+# Path to a JSON file containing specific DMP DOIs to include.
+DMP_SUBSET_DOIS_PATH=${DATA_DIR}/meta/dmp_dois.json
 
 ######################################
 # Run Identifiers

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -11,7 +11,7 @@ This section covers environment variables, local services, and test setup.
 Create a `.env.local` file from `.env.local.example` and fill in the required values.
 
 `dmpworks` loads `.env.local` automatically when invoked (the default). You can override
-this using `--env-file` or the `DMPWORKS_ENV` environment variable:
+this using `--env-file` or the `DMPWORKS_ENV_FILE` environment variable:
 
 ```bash
 # Use an explicit file

--- a/python/dmpworks/batch/cli.py
+++ b/python/dmpworks/batch/cli.py
@@ -5,9 +5,9 @@ from cyclopts import App
 from dmpworks.cli_utils import (
     CrossrefMetadataTransformConfig,
     DataCiteTransformConfig,
-    DatasetSubset,
+    DatasetSubsetAWS,
     Date,
-    DMPSubset,
+    DMPSubsetAWS,
     LogLevel,
     MySQLConfig,
     OpenAlexWorksTransformConfig,
@@ -61,7 +61,7 @@ def datacite_download_cmd(
 def datacite_dataset_subset_cmd(
     bucket_name: str,
     run_id: str,
-    dataset_subset: DatasetSubset,
+    dataset_subset: DatasetSubsetAWS,
     log_level: LogLevel = "INFO",
 ):
     """Create a subset of DataCite.
@@ -79,7 +79,7 @@ def datacite_dataset_subset_cmd(
     datacite.dataset_subset(
         bucket_name=bucket_name,
         run_id=run_id,
-        dataset_subset=dataset_subset,
+        ds_config=dataset_subset,
     )
 
 
@@ -151,7 +151,7 @@ def openalex_works_download_cmd(
 def openalex_works_dataset_subset_cmd(
     bucket_name: str,
     run_id: str,
-    dataset_subset: DatasetSubset = None,
+    dataset_subset: DatasetSubsetAWS = None,
     log_level: LogLevel = "INFO",
 ):
     """Create a subset of OpenAlex Works.
@@ -169,7 +169,7 @@ def openalex_works_dataset_subset_cmd(
     openalex_works.dataset_subset(
         bucket_name=bucket_name,
         run_id=run_id,
-        dataset_subset=dataset_subset,
+        ds_config=dataset_subset,
     )
 
 
@@ -239,7 +239,7 @@ def crossref_metadata_download_cmd(
 def crossref_metadata_dataset_subset_cmd(
     bucket_name: str,
     run_id: str,
-    dataset_subset: DatasetSubset = None,
+    dataset_subset: DatasetSubsetAWS = None,
     log_level: LogLevel = "INFO",
 ):
     """Create a subset of Crossref Metadata.
@@ -254,7 +254,7 @@ def crossref_metadata_dataset_subset_cmd(
     from dmpworks.utils import setup_multiprocessing_logging
 
     setup_multiprocessing_logging(logging.getLevelName(log_level))
-    crossref_metadata.dataset_subset(bucket_name=bucket_name, run_id=run_id, dataset_subset=dataset_subset)
+    crossref_metadata.dataset_subset(bucket_name=bucket_name, run_id=run_id, ds_config=dataset_subset,)
 
 
 @crossref_metadata_app.command(name="transform")
@@ -373,10 +373,45 @@ def opensearch_sync_works_cmd(
     )
 
 
+@opensearch_app.command(name="sync-dmps")
+def opensearch_sync_dmps_cmd(
+    bucket_name: str,
+    index_name: str,
+    mysql_config: MySQLConfig,
+    client_config: OpenSearchClientConfig | None = None,
+    dmp_subset: DMPSubsetAWS | None = None,
+    log_level: LogLevel = "INFO",
+):
+    """Sync DMPs from MySQL with OpenSearch DMPs index.
+
+    Args:
+        bucket_name: DMP Tool S3 bucket name.
+        index_name: the OpenSearch DMPs index name.
+        mysql_config: MySQL connection configuration.
+        client_config: the OpenSearch client config settings.
+        dmp_subset: settings for including a subset of DMPs.
+        log_level: Python log level.
+    """
+    from dmpworks.batch import opensearch
+
+    client_config = OpenSearchClientConfig() if client_config is None else client_config
+    level = logging.getLevelName(log_level)
+    logging.basicConfig(level=level)
+    opensearch.sync_dmps_cmd(
+        bucket_name=bucket_name,
+        index_name=index_name,
+        client_config=client_config,
+        mysql_config=mysql_config,
+        dmp_subset=dmp_subset,
+    )
+
+
 @opensearch_app.command(name="enrich-dmps")
 def opensearch_enrich_dmps_cmd(
     index_name: str,
     client_config: OpenSearchClientConfig | None = None,
+    bucket_name: str | None = None,
+    dmp_subset: DMPSubsetAWS | None = None,
     log_level: LogLevel = "INFO",
 ):
     """Enrich dmps in the OpenSearch DMPs index.
@@ -384,6 +419,8 @@ def opensearch_enrich_dmps_cmd(
     Args:
         index_name: the OpenSearch index name.
         client_config: the OpenSearch client config settings.
+        bucket_name: DMP Tool S3 bucket name (required when dmp_subset is provided).
+        dmp_subset: settings for including a subset of DMPs.
         log_level: Python log level.
     """
     from dmpworks.batch import opensearch
@@ -394,6 +431,8 @@ def opensearch_enrich_dmps_cmd(
     opensearch.enrich_dmps_cmd(
         index_name=index_name,
         client_config=client_config,
+        bucket_name=bucket_name,
+        dmp_subset=dmp_subset,
     )
 
 
@@ -412,7 +451,7 @@ def opensearch_dmp_works_search_cmd(
     max_concurrent_searches: int = 125,
     max_concurrent_shard_requests: int = 12,
     client_config: OpenSearchClientConfig | None = None,
-    dmp_subset: DMPSubset | None = None,
+    dmp_subset: DMPSubsetAWS | None = None,
     start_date: Date = None,
     end_date: Date = None,
     log_level: LogLevel = "INFO",

--- a/python/dmpworks/batch/crossref_metadata.py
+++ b/python/dmpworks/batch/crossref_metadata.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from dmpworks.batch.tasks import dataset_subset_task, download_source_task, transform_parquets_task
 from dmpworks.batch.utils import s3_uri
-from dmpworks.cli_utils import CrossrefMetadataTransformConfig, DatasetSubset
+from dmpworks.cli_utils import CrossrefMetadataTransformConfig, DatasetSubsetAWS
 from dmpworks.transform.crossref_metadata import transform_crossref_metadata
 from dmpworks.transform.dataset_subset import create_dataset_subset
 from dmpworks.utils import run_process
@@ -54,20 +54,20 @@ def dataset_subset(
     *,
     bucket_name: str,
     run_id: str,
-    dataset_subset: DatasetSubset = None,
+    ds_config: DatasetSubsetAWS = None,
 ):
     """Create a subset of Crossref Metadata.
 
     Args:
         bucket_name: the name of the S3 bucket for JOB I/O.
         run_id: a unique ID to represent this run of the job.
-        dataset_subset: settings for creating the subset of works
+        ds_config: settings for creating the subset of works
     """
     with dataset_subset_task(
         bucket_name=bucket_name,
         dataset=DATASET,
         run_id=run_id,
-        dataset_subset=dataset_subset,
+        dataset_subset=ds_config,
     ) as ctx:
         create_dataset_subset(
             dataset="crossref-metadata",

--- a/python/dmpworks/batch/datacite.py
+++ b/python/dmpworks/batch/datacite.py
@@ -3,7 +3,7 @@ import os
 
 from dmpworks.batch.tasks import dataset_subset_task, download_source_task, transform_parquets_task
 from dmpworks.batch.utils import s3_uri
-from dmpworks.cli_utils import DataCiteTransformConfig, DatasetSubset
+from dmpworks.cli_utils import DataCiteTransformConfig, DatasetSubsetAWS
 from dmpworks.transform.datacite import transform_datacite
 from dmpworks.transform.dataset_subset import create_dataset_subset
 from dmpworks.utils import fetch_datacite_aws_credentials, run_process
@@ -49,20 +49,20 @@ def dataset_subset(
     *,
     bucket_name: str,
     run_id: str,
-    dataset_subset: DatasetSubset,
+    ds_config: DatasetSubsetAWS,
 ):
     """Create a subset of DataCite.
 
     Args:
         bucket_name: the name of the S3 bucket for JOB I/O.
         run_id: a unique ID to represent this run of the job.
-        dataset_subset: settings for creating the subset of works
+        ds_config: settings for creating the subset of works
     """
     with dataset_subset_task(
         bucket_name=bucket_name,
         dataset=DATASET,
         run_id=run_id,
-        dataset_subset=dataset_subset,
+        dataset_subset=ds_config,
     ) as ctx:
         create_dataset_subset(
             dataset="datacite",

--- a/python/dmpworks/batch/openalex_works.py
+++ b/python/dmpworks/batch/openalex_works.py
@@ -2,7 +2,7 @@ import logging
 
 from dmpworks.batch.tasks import dataset_subset_task, download_source_task, transform_parquets_task
 from dmpworks.batch.utils import s3_uri
-from dmpworks.cli_utils import DatasetSubset, OpenAlexWorksTransformConfig
+from dmpworks.cli_utils import DatasetSubsetAWS, OpenAlexWorksTransformConfig
 from dmpworks.transform.dataset_subset import create_dataset_subset
 from dmpworks.transform.openalex_works import transform_openalex_works
 from dmpworks.utils import run_process
@@ -36,20 +36,20 @@ def dataset_subset(
     *,
     bucket_name: str,
     run_id: str,
-    dataset_subset: DatasetSubset = None,
+    ds_config: DatasetSubsetAWS = None,
 ):
     """Create a subset of OpenAlex Works.
 
     Args:
         bucket_name: the name of the S3 bucket for JOB I/O.
         run_id: a unique ID to represent this run of the job.
-        dataset_subset: settings for creating the subset of works
+        ds_config: settings for creating the subset of works
     """
     with dataset_subset_task(
         bucket_name=bucket_name,
         dataset=DATASET,
         run_id=run_id,
-        dataset_subset=dataset_subset,
+        dataset_subset=ds_config,
     ) as ctx:
         create_dataset_subset(
             dataset="openalex-works",

--- a/python/dmpworks/batch/opensearch.py
+++ b/python/dmpworks/batch/opensearch.py
@@ -11,15 +11,52 @@ from dmpworks.batch.utils import (
     s3_uri,
     upload_files_to_s3,
 )
-from dmpworks.cli_utils import DMPSubset, LogLevel, MySQLConfig, OpenSearchClientConfig, OpenSearchSyncConfig
+from dmpworks.cli_utils import DMPSubsetAWS, LogLevel, MySQLConfig, OpenSearchClientConfig, OpenSearchSyncConfig
 from dmpworks.dataset_subset import load_dois, load_institutions
 
 log = logging.getLogger(__name__)
 
 SQLMESH_DIR = "sqlmesh"
-MATCHES_DIR_NAME = "matches"
-DMP_WORKS_SEARCH_PATH = "dmp-works-search"
+MATCHES_DIR = "matches"
+DMP_WORKS_SEARCH_DIR = "dmp-works-search"
+META_DIR = "meta"
 DATASET = "opensearch"
+
+
+def load_dmp_subset_from_s3(
+    bucket_name: str,
+    dmp_subset: DMPSubsetAWS | None,
+    meta_dir,
+):
+    """Download and load DMP subset institutions and DOIs from S3.
+
+    Args:
+        bucket_name: DMP Tool S3 bucket name.
+        dmp_subset: DMP subset configuration.
+        meta_dir: Local directory to download files into.
+
+    Returns:
+        tuple[list | None, list[str] | None]: Loaded institutions and DOIs, or None if not configured.
+    """
+    use_subset = dmp_subset is not None and dmp_subset.enable
+    institutions = None
+    dois = None
+
+    if use_subset and dmp_subset.institutions_s3_path is not None:
+        institutions_uri = s3_uri(bucket_name, dmp_subset.institutions_s3_path)
+        institutions_path = meta_dir / "institutions.json"
+        download_file_from_s3(institutions_uri, institutions_path)
+        institutions = load_institutions(institutions_path)
+        logging.info(f"institutions: {institutions}")
+
+    if use_subset and dmp_subset.dois_s3_path is not None:
+        dois_uri = s3_uri(bucket_name, dmp_subset.dois_s3_path)
+        dois_path = meta_dir / "dois.json"
+        download_file_from_s3(dois_uri, dois_path)
+        dois = load_dois(dois_path)
+        logging.info(f"dois: {dois}")
+
+    return institutions, dois
 
 
 def sync_works_cmd(
@@ -71,22 +108,77 @@ def sync_works_cmd(
         shutil.rmtree(doi_state_export, ignore_errors=True)
 
 
+def sync_dmps_cmd(
+    *,
+    bucket_name: str,
+    index_name: str,
+    client_config: OpenSearchClientConfig,
+    mysql_config: MySQLConfig,
+    dmp_subset: DMPSubsetAWS | None = None,
+):
+    """Sync DMPs from MySQL into the OpenSearch DMPs index, with optional subset filtering.
+
+    Downloads institution and DOI subset files from S3 when configured, then syncs
+    only the matching DMPs.
+
+    Args:
+        bucket_name: DMP Tool S3 bucket name.
+        index_name: the OpenSearch DMPs index name.
+        client_config: the OpenSearch client config settings.
+        mysql_config: MySQL connection configuration.
+        dmp_subset: settings for including a subset of DMPs.
+    """
+    from dmpworks.opensearch.sync_dmps import sync_dmps  # noqa: PLC0415
+
+    logging.getLogger("opensearch").setLevel(logging.WARNING)
+
+    meta_dir = local_path(META_DIR)
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        institutions, dois = load_dmp_subset_from_s3(bucket_name, dmp_subset, meta_dir)
+        sync_dmps(
+            index_name,
+            mysql_config,
+            opensearch_config=client_config,
+            institutions=institutions,
+            dois=dois,
+        )
+    finally:
+        shutil.rmtree(meta_dir, ignore_errors=True)
+
+
 def enrich_dmps_cmd(
     *,
     index_name: str,
     client_config: OpenSearchClientConfig,
+    bucket_name: str | None = None,
+    dmp_subset: DMPSubsetAWS | None = None,
 ):
     """Enrich dmps in the OpenSearch DMPs index.
 
     Args:
         index_name: the OpenSearch index name.
         client_config: the OpenSearch client config settings.
+        bucket_name: DMP Tool S3 bucket name (required when dmp_subset is provided).
+        dmp_subset: settings for including a subset of DMPs.
     """
     from dmpworks.opensearch.enrich_dmps import enrich_dmps  # noqa: PLC0415
 
     logging.getLogger("opensearch").setLevel(logging.WARNING)
 
-    enrich_dmps(index_name, client_config)
+    institutions = None
+    dois = None
+    meta_dir = None
+    if dmp_subset is not None and dmp_subset.enable and bucket_name is not None:
+        meta_dir = local_path(META_DIR)
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        institutions, dois = load_dmp_subset_from_s3(bucket_name, dmp_subset, meta_dir)
+
+    try:
+        enrich_dmps(index_name, client_config, institutions=institutions, dois=dois)
+    finally:
+        if meta_dir is not None:
+            shutil.rmtree(meta_dir, ignore_errors=True)
 
 
 def dmp_works_search_cmd(
@@ -104,7 +196,7 @@ def dmp_works_search_cmd(
     max_concurrent_searches: int = 125,
     max_concurrent_shard_requests: int = 12,
     client_config: OpenSearchClientConfig | None = None,
-    dmp_subset: DMPSubset = None,
+    dmp_subset: DMPSubsetAWS = None,
     start_date: pendulum.Date | None = None,
     end_date: pendulum.Date | None = None,
 ):
@@ -135,35 +227,15 @@ def dmp_works_search_cmd(
 
     logging.getLogger("opensearch").setLevel(logging.WARNING)
 
-    out_dir = local_path(DMP_WORKS_SEARCH_PATH, run_id, MATCHES_DIR_NAME)
+    out_dir = local_path(DMP_WORKS_SEARCH_DIR, run_id, MATCHES_DIR)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    meta_dir = local_path(DMP_WORKS_SEARCH_PATH, run_id, "meta")
+    meta_dir = local_path(DMP_WORKS_SEARCH_DIR, run_id, META_DIR)
     meta_dir.mkdir(parents=True, exist_ok=True)
 
-    # Load subset
-    use_subset = dmp_subset is not None and dmp_subset.enable
-    logging.info(f"use_subset: {use_subset}")
-
-    # Download institutions
-    institutions = None
-    if use_subset and dmp_subset.institutions_s3_path is not None:
-        institutions_uri = s3_uri(bucket_name, dmp_subset.institutions_s3_path)
-        institutions_path = meta_dir / "institutions.json"
-        download_file_from_s3(institutions_uri, institutions_path)
-        institutions = load_institutions(institutions_path)
-        logging.info(f"institutions: {institutions}")
-
-    # Download DOIs
-    dois = None
-    if use_subset and dmp_subset.dois_s3_path is not None:
-        dois_uri = s3_uri(bucket_name, dmp_subset.dois_s3_path)
-        dois_path = meta_dir / "dois.json"
-        download_file_from_s3(dois_uri, dois_path)
-        dois = load_dois(dois_path)
-        logging.info(f"dois: {dois}")
-
     try:
+        institutions, dois = load_dmp_subset_from_s3(bucket_name, dmp_subset, meta_dir)
+
         dmp_works_search(
             dmps_index_name,
             works_index_name,
@@ -184,7 +256,7 @@ def dmp_works_search_cmd(
         )
 
         # Upload all Parquet files to S3
-        target_uri = s3_uri(bucket_name, DMP_WORKS_SEARCH_PATH, run_id, MATCHES_DIR_NAME)
+        target_uri = s3_uri(bucket_name, DMP_WORKS_SEARCH_DIR, run_id, MATCHES_DIR)
         upload_files_to_s3(out_dir, target_uri, glob_pattern="*.parquet")
     finally:
         shutil.rmtree(out_dir, ignore_errors=True)
@@ -207,11 +279,11 @@ def merge_related_works_cmd(
     """
     from dmpworks.dmsp.related_works import merge_related_works  # noqa: PLC0415
 
-    matches_dir = local_path(DMP_WORKS_SEARCH_PATH, run_id, MATCHES_DIR_NAME)
+    matches_dir = local_path(DMP_WORKS_SEARCH_DIR, run_id, MATCHES_DIR)
     matches_dir.mkdir(parents=True, exist_ok=True)
     try:
         # Download all Parquet files from S3
-        source_uri = s3_uri(bucket_name, DMP_WORKS_SEARCH_PATH, run_id, MATCHES_DIR_NAME, "*.parquet")
+        source_uri = s3_uri(bucket_name, DMP_WORKS_SEARCH_DIR, run_id, MATCHES_DIR, "*.parquet")
         download_files_from_s3(source_uri, matches_dir)
 
         # Upsert data

--- a/python/dmpworks/batch/tasks.py
+++ b/python/dmpworks/batch/tasks.py
@@ -14,7 +14,7 @@ from dmpworks.batch.utils import (
     s3_uri,
     upload_files_to_s3,
 )
-from dmpworks.cli_utils import DatasetSubset
+from dmpworks.cli_utils import DatasetSubsetAWS
 from dmpworks.dataset_subset import load_dois, load_institutions
 from dmpworks.model.common import Institution
 
@@ -69,7 +69,7 @@ def download_source_task(bucket_name: str, dataset: str, run_id: str) -> Generat
 
 
 @dataclass
-class DatasetSubsetTaskContext:
+class DatasetSubsetAWSTaskContext:
     """Context for a dataset subset task.
 
     Attributes:
@@ -93,8 +93,8 @@ def dataset_subset_task(
     bucket_name: str,
     dataset: str,
     run_id: str,
-    dataset_subset: DatasetSubset,
-) -> Generator[DatasetSubsetTaskContext, Any, None]:
+    dataset_subset: DatasetSubsetAWS,
+) -> Generator[DatasetSubsetAWSTaskContext, Any, None]:
     """Context manager for creating a dataset subset.
 
     Downloads institutions and DOIs for filtering.
@@ -109,7 +109,7 @@ def dataset_subset_task(
         dataset_subset: Configuration for the dataset subset.
 
     Yields:
-        A DatasetSubsetTaskContext object.
+        A DatasetSubsetAWSTaskContext object.
     """
     meta_dir = local_path(dataset, run_id, "meta")
     download_dir = local_path(dataset, run_id, "download")
@@ -137,7 +137,7 @@ def dataset_subset_task(
     subset_dir.mkdir(parents=True, exist_ok=True)
 
     log.info(f"Transforming {dataset}")
-    ctx = DatasetSubsetTaskContext(
+    ctx = DatasetSubsetAWSTaskContext(
         download_dir=download_dir,
         subset_dir=subset_dir,
         target_uri=target_uri,

--- a/python/dmpworks/batch_submit/cli.py
+++ b/python/dmpworks/batch_submit/cli.py
@@ -7,8 +7,8 @@ from cyclopts import App, Parameter
 from dmpworks.cli_utils import (
     CrossrefMetadataTransformConfig,
     DataCiteTransformConfig,
-    DatasetSubset,
-    DMPSubset,
+    DatasetSubsetAWS,
+    DMPSubsetAWS,
     LogLevel,
     OpenAlexWorksTransformConfig,
     OpenSearchClientConfig,
@@ -150,7 +150,7 @@ def crossref_metadata_cmd(
             help="Name of the Crossref AWS S3 bucket.",
         ),
     ],
-    dataset_subset: DatasetSubset = None,
+    dataset_subset: DatasetSubsetAWS = None,
     config: CrossrefMetadataTransformConfig | None = None,
     log_level: LogLevel = "INFO",
     start_job: Annotated[
@@ -257,7 +257,7 @@ def datacite_cmd(
             help="Name of the DataCite AWS S3 bucket.",
         ),
     ],
-    dataset_subset: DatasetSubset = None,
+    dataset_subset: DatasetSubsetAWS = None,
     config: DataCiteTransformConfig | None = None,
     log_level: LogLevel = "INFO",
     start_job: Annotated[
@@ -362,7 +362,7 @@ def openalex_works_cmd(
             help="Name of the OpenAlex AWS S3 bucket.",
         ),
     ],
-    dataset_subset: DatasetSubset = None,
+    dataset_subset: DatasetSubsetAWS = None,
     config: OpenAlexWorksTransformConfig | None = None,
     log_level: LogLevel = "INFO",
     start_job: Annotated[
@@ -551,7 +551,7 @@ def process_dmps_cmd(
     ] = "works-index",
     os_client_config: OpenSearchClientConfig | None = None,
     os_sync_config: OpenSearchSyncConfig | None = None,
-    dmp_subset: DMPSubset = None,
+    dmp_subset: DMPSubsetAWS = None,
     start_job: Annotated[
         Literal[*PROCESS_DMPS_JOBS],
         Parameter(
@@ -592,17 +592,21 @@ def process_dmps_cmd(
         "sync-dmps": partial(
             submit_sync_dmps_job,
             env=env,
+            bucket_name=bucket_name,
             run_id_dmps=run_id_dmps,
             os_client_config=os_client_config,
             os_sync_config=os_sync_config,
             index_name=dmps_index_name,
+            dmp_subset=dmp_subset,
         ),
         "enrich-dmps": partial(
             submit_enrich_dmps_job,
             env=env,
+            bucket_name=bucket_name,
             run_id_dmps=run_id_dmps,
             index_name=dmps_index_name,
             os_client_config=os_client_config,
+            dmp_subset=dmp_subset,
         ),
         "dmp-works-search": partial(
             submit_dmp_works_search_job,

--- a/python/dmpworks/batch_submit/jobs.py
+++ b/python/dmpworks/batch_submit/jobs.py
@@ -9,8 +9,8 @@ import pendulum
 from dmpworks.cli_utils import (
     CrossrefMetadataTransformConfig,
     DataCiteTransformConfig,
-    DatasetSubset,
-    DMPSubset,
+    DatasetSubsetAWS,
+    DMPSubsetAWS,
     OpenAlexWorksTransformConfig,
     OpenSearchClientConfig,
     OpenSearchSyncConfig,
@@ -257,7 +257,7 @@ def dataset_subset_job(
     bucket_name: str,
     run_id: str,
     dataset: Dataset,
-    dataset_subset: DatasetSubset,
+    dataset_subset: DatasetSubsetAWS,
     vcpus: int = LARGE_VCPUS,
     memory: int = LARGE_MEMORY,
     depends_on: list[DependsOnDict] | None = None,
@@ -723,10 +723,12 @@ def submit_sync_works_job(
 def submit_sync_dmps_job(
     *,
     env: str,
+    bucket_name: str,
     run_id_dmps: str,
     os_client_config: OpenSearchClientConfig | None = None,
     os_sync_config: OpenSearchSyncConfig | None = None,
     index_name: str = "dmps-index",
+    dmp_subset: DMPSubsetAWS | None = None,
     vcpus: int = SMALL_VCPUS,
     memory: int = SMALL_MEMORY,
     depends_on: list[DependsOnDict] | None = None,
@@ -735,10 +737,12 @@ def submit_sync_dmps_job(
 
     Args:
         env: environment, i.e., dev, stage, prod.
+        bucket_name: S3 bucket for job I/O and DMP subset downloads.
         run_id_dmps: The run_id of the DMPs data to use.
         os_client_config: The OpenSearch client config.
         os_sync_config: The OpenSearch sync config.
         index_name: The name of the OpenSearch index to sync to.
+        dmp_subset: settings for including a subset of DMPs.
         vcpus: number of vCPUs for the job.
         memory: memory (in MiB) for the job.
         depends_on: optional list of job dependencies.
@@ -752,12 +756,15 @@ def submit_sync_dmps_job(
         os_sync_config = OpenSearchSyncConfig()
 
     env_vars = {
+        "BUCKET_NAME": bucket_name,
         "INDEX_NAME": index_name,
         "TQDM_POSITION": TQDM_POSITION,
         "TQDM_MININTERVAL": TQDM_MININTERVAL,
     }
     env_vars.update(get_env_var_dict(os_client_config))
     env_vars.update(get_env_var_dict(os_sync_config))
+    if dmp_subset is not None:
+        env_vars.update(get_env_var_dict(dmp_subset))
 
     return submit_job(
         job_name="opensearch-sync-dmps",
@@ -766,7 +773,7 @@ def submit_sync_dmps_job(
         job_definition=database_job_definition(env),
         vcpus=vcpus,
         memory=memory,
-        command="dmpworks opensearch sync-dmps $INDEX_NAME",
+        command="dmpworks aws-batch opensearch sync-dmps $BUCKET_NAME $INDEX_NAME",
         environment=make_env(env_vars),
         depends_on=depends_on,
     )
@@ -775,9 +782,11 @@ def submit_sync_dmps_job(
 def submit_enrich_dmps_job(
     *,
     env: str,
+    bucket_name: str,
     run_id_dmps: str,
     os_client_config: OpenSearchClientConfig | None = None,
     index_name: str = "dmps-index",
+    dmp_subset: DMPSubsetAWS | None = None,
     vcpus: int = SMALL_VCPUS,
     memory: int = SMALL_MEMORY,
     depends_on: list[DependsOnDict] | None = None,
@@ -786,9 +795,11 @@ def submit_enrich_dmps_job(
 
     Args:
         env: environment, i.e., dev, stage, prod.
+        bucket_name: S3 bucket for DMP subset downloads.
         run_id_dmps: The run_id of the DMPs data, used for job tracking.
         os_client_config: The OpenSearch client config.
         index_name: The name of the OpenSearch DMPs index to enrich.
+        dmp_subset: settings for including a subset of DMPs.
         vcpus: number of vCPUs for the job.
         memory: memory (in MiB) for the job.
         depends_on: optional list of job dependencies.
@@ -800,11 +811,14 @@ def submit_enrich_dmps_job(
         os_client_config = OpenSearchClientConfig()
 
     env_vars = {
+        "BUCKET_NAME": bucket_name,
         "INDEX_NAME": index_name,
         "TQDM_POSITION": TQDM_POSITION,
         "TQDM_MININTERVAL": TQDM_MININTERVAL,
     }
     env_vars.update(get_env_var_dict(os_client_config))
+    if dmp_subset is not None:
+        env_vars.update(get_env_var_dict(dmp_subset))
 
     return submit_job(
         job_name="opensearch-enrich-dmps",
@@ -813,7 +827,7 @@ def submit_enrich_dmps_job(
         job_definition=standard_job_definition(env),
         vcpus=vcpus,
         memory=memory,
-        command="dmpworks aws-batch opensearch enrich-dmps $INDEX_NAME",
+        command="dmpworks aws-batch opensearch enrich-dmps $INDEX_NAME --bucket-name $BUCKET_NAME",
         environment=make_env(env_vars),
         depends_on=depends_on,
     )
@@ -827,7 +841,7 @@ def submit_dmp_works_search_job(
     os_client_config: OpenSearchClientConfig | None = None,
     dmps_index_name: str = "dmps-index",
     works_index_name: str = "works-index",
-    dmp_subset: DMPSubset,
+    dmp_subset: DMPSubsetAWS,
     vcpus: int = SMALL_VCPUS,
     memory: int = SMALL_MEMORY,
     depends_on: list[DependsOnDict] | None = None,

--- a/python/dmpworks/cli_utils.py
+++ b/python/dmpworks/cli_utils.py
@@ -110,8 +110,8 @@ QueryBuilder = Literal["build_dmp_works_search_baseline_query", "build_dmp_works
 
 
 @dataclass
-class DatasetSubset:
-    """Cyclopts configuration for creating a subset of datasets.
+class DatasetSubsetAWS:
+    """Cyclopts configuration for creating a subset of datasets (AWS).
 
     Attributes:
         enable: Enable subset creation to filter works by specific institutions or a list of DOIs.
@@ -143,8 +143,41 @@ class DatasetSubset:
 
 
 @dataclass
-class DMPSubset:
-    """Cyclopts configuration for creating a subset of DMPs.
+class DatasetSubsetLocal:
+    """Cyclopts configuration for creating a subset of datasets (local).
+
+    Attributes:
+        enable: Enable subset creation to filter works by specific institutions or a list of DOIs.
+        institutions_path: Path to a JSON file containing ROR IDs and institution names.
+        dois_path: Path to a JSON file containing specific Work DOIs to include in the subset.
+    """
+
+    enable: Annotated[
+        bool,
+        Parameter(
+            env_var="DATASET_SUBSET_ENABLE",
+            help="Enable subset creation to filter works by specific institutions or a list of DOIs.",
+        ),
+    ] = False
+    institutions_path: Annotated[
+        pathlib.Path | None,
+        Parameter(
+            env_var="DATASET_SUBSET_INSTITUTIONS_PATH",
+            help="Path to a JSON file containing ROR IDs and institution names. Works authored by researchers from these institutions will be included.",
+        ),
+    ] = None
+    dois_path: Annotated[
+        pathlib.Path | None,
+        Parameter(
+            env_var="DATASET_SUBSET_DOIS_PATH",
+            help="Path to a JSON file containing specific Work DOIs to include in the subset.",
+        ),
+    ] = None
+
+
+@dataclass
+class DMPSubsetAWS:
+    """Cyclopts configuration for creating a subset of DMPs (AWS).
 
     Attributes:
         enable: Enable subset creation to filter DMPs by specific institutions or a list of DOIs.
@@ -171,6 +204,39 @@ class DMPSubset:
         Parameter(
             env_var="DMP_SUBSET_DOIS_S3_PATH",
             help="S3 path (excluding bucket URI) to a specific list of DMP DOIs to include in the subset.",
+        ),
+    ] = None
+
+
+@dataclass
+class DMPSubsetLocal:
+    """Cyclopts configuration for creating a subset of DMPs (local).
+
+    Attributes:
+        enable: Enable subset creation to filter DMPs by specific institutions or a list of DOIs.
+        institutions_path: Path to a JSON file containing ROR IDs and institution names.
+        dois_path: Path to a JSON file containing specific DMP DOIs to include in the subset.
+    """
+
+    enable: Annotated[
+        bool,
+        Parameter(
+            env_var="DMP_SUBSET_ENABLE",
+            help="Enable subset creation to filter DMPs by specific institutions or a list of DOIs.",
+        ),
+    ] = False
+    institutions_path: Annotated[
+        pathlib.Path | None,
+        Parameter(
+            env_var="DMP_SUBSET_INSTITUTIONS_PATH",
+            help="Path to a JSON file containing ROR IDs and institution names. DMPs created by researchers from these institutions will be included.",
+        ),
+    ] = None
+    dois_path: Annotated[
+        pathlib.Path | None,
+        Parameter(
+            env_var="DMP_SUBSET_DOIS_PATH",
+            help="Path to a JSON file containing specific DMP DOIs to include in the subset.",
         ),
     ] = None
 

--- a/python/dmpworks/dataset_subset.py
+++ b/python/dmpworks/dataset_subset.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from pydantic import TypeAdapter
 
 from dmpworks.model.common import Institution
+from dmpworks.transform.simdjson_transforms import extract_doi, extract_ror
 
 if TYPE_CHECKING:
     import pathlib
@@ -13,6 +14,9 @@ if TYPE_CHECKING:
 
 def load_institutions(file_path: pathlib.Path) -> list[Institution]:
     """Load a list of institutions from a JSON file.
+
+    ROR IDs are extracted and normalised using extract_ror. Institutions where
+    both name and ror are None after processing are excluded.
 
     Args:
         file_path: The path to the JSON file containing institution data.
@@ -31,7 +35,15 @@ def load_institutions(file_path: pathlib.Path) -> list[Institution]:
         with file_path.open() as f:
             json_data = json.load(f)
             institutions_list_adapter = TypeAdapter(list[Institution])
-            return institutions_list_adapter.validate_python(json_data)
+            institutions = institutions_list_adapter.validate_python(json_data)
+            result = []
+            for inst in institutions:
+                ror = extract_ror(inst.ror)
+                name = inst.name
+                if name is None and ror is None:
+                    continue
+                result.append(Institution(name=name, ror=ror))
+            return result
     except json.JSONDecodeError as e:
         raise ValueError("Invalid JSON provided") from e
 
@@ -39,11 +51,14 @@ def load_institutions(file_path: pathlib.Path) -> list[Institution]:
 def load_dois(file_path: pathlib.Path) -> list[str]:
     """Load a list of DOIs from a JSON file.
 
+    DOIs are extracted and normalised using extract_doi. Entries that do not
+    contain a valid DOI are excluded.
+
     Args:
         file_path: The path to the JSON file containing DOI strings.
 
     Returns:
-        A list of DOI strings.
+        A list of normalised DOI strings.
 
     Raises:
         FileNotFoundError: If the file does not exist.
@@ -56,6 +71,7 @@ def load_dois(file_path: pathlib.Path) -> list[str]:
         with file_path.open() as f:
             json_data = json.load(f)
             str_list_adapter = TypeAdapter(list[str])
-            return str_list_adapter.validate_python(json_data)
+            raw_dois = str_list_adapter.validate_python(json_data)
+            return [doi for raw in raw_dois if (doi := extract_doi(raw)) is not None]
     except json.JSONDecodeError as e:
         raise ValueError("Invalid JSON provided") from e

--- a/python/dmpworks/opensearch/cli.py
+++ b/python/dmpworks/opensearch/cli.py
@@ -7,6 +7,7 @@ from cyclopts import App, Parameter, validators
 from dmpworks.cli_utils import (
     Date,
     Directory,
+    DMPSubsetLocal,
     LogLevel,
     MySQLConfig,
     OpenSearchClientConfig,
@@ -15,6 +16,29 @@ from dmpworks.cli_utils import (
 )
 
 app = App(name="opensearch", help="OpenSearch utilities.")
+
+
+def load_dmp_subset_local(
+    dmp_subset: DMPSubsetLocal | None,
+) -> tuple[list | None, list[str] | None]:
+    """Load institutions and DOIs from local files based on DMPSubsetLocal config.
+
+    Args:
+        dmp_subset: Local DMP subset configuration.
+
+    Returns:
+        tuple[list | None, list[str] | None]: Loaded institutions and DOIs, or None if not configured.
+    """
+    from dmpworks.dataset_subset import load_dois, load_institutions  # noqa: PLC0415
+
+    use_subset = dmp_subset is not None and dmp_subset.enable
+    institutions = None
+    dois = None
+    if use_subset and dmp_subset.institutions_path is not None:
+        institutions = load_institutions(dmp_subset.institutions_path)
+    if use_subset and dmp_subset.dois_path is not None:
+        dois = load_dois(dmp_subset.dois_path)
+    return institutions, dois
 
 
 @app.command(name="create-index")
@@ -122,6 +146,7 @@ def sync_dmps_cmd(
     mysql_config: MySQLConfig,
     opensearch_config: OpenSearchClientConfig | None = None,
     chunk_size: int = 1000,
+    dmp_subset: DMPSubsetLocal | None = None,
     log_level: LogLevel = "INFO",
 ):
     """Sync DMPs from MySQL with OpenSearch DMPs index.
@@ -131,6 +156,7 @@ def sync_dmps_cmd(
         mysql_config: MySQL config.
         opensearch_config: OpenSearch client settings.
         chunk_size: OpenSearch bulk indexing chunk size.
+        dmp_subset: Settings for including a subset of DMPs.
         log_level: Python log level (e.g., INFO).
     """
     from dmpworks.opensearch.sync_dmps import sync_dmps
@@ -142,11 +168,14 @@ def sync_dmps_cmd(
     logging.basicConfig(level=level)
     logging.getLogger("opensearch").setLevel(logging.WARNING)
 
+    institutions, dois = load_dmp_subset_local(dmp_subset)
     sync_dmps(
         index_name,
         mysql_config,
         opensearch_config=opensearch_config,
         chunk_size=chunk_size,
+        institutions=institutions,
+        dois=dois,
     )
 
 
@@ -154,6 +183,7 @@ def sync_dmps_cmd(
 def enrich_dmps_cmd(
     dmps_index_name: str,
     client_config: OpenSearchClientConfig | None = None,
+    dmp_subset: DMPSubsetLocal | None = None,
     log_level: LogLevel = "INFO",
 ):
     """Enrich DMPs in OpenSearch with publications found on funder award pages.
@@ -161,6 +191,7 @@ def enrich_dmps_cmd(
     Args:
         dmps_index_name: Name of the DMP index to update.
         client_config: OpenSearch client settings.
+        dmp_subset: Settings for including a subset of DMPs.
         log_level: Python log level (e.g., INFO).
     """
     from dmpworks.opensearch.enrich_dmps import enrich_dmps
@@ -172,9 +203,12 @@ def enrich_dmps_cmd(
     logging.basicConfig(level=level)
     logging.getLogger("opensearch").setLevel(logging.WARNING)
 
+    institutions, dois = load_dmp_subset_local(dmp_subset)
     enrich_dmps(
         dmps_index_name,
         client_config,
+        institutions=institutions,
+        dois=dois,
     )
 
 
@@ -203,28 +237,9 @@ def dmp_works_search_cmd(
     max_concurrent_searches: int = 125,
     max_concurrent_shard_requests: int = 12,
     client_config: OpenSearchClientConfig | None = None,
-    institutions_file: Annotated[
-        pathlib.Path | None,
-        Parameter(
-            validator=validators.Path(
-                dir_okay=False,
-                file_okay=True,
-                exists=True,
-            )
-        ),
-    ] = None,
-    dois_file: Annotated[
-        pathlib.Path | None,
-        Parameter(
-            validator=validators.Path(
-                dir_okay=False,
-                file_okay=True,
-                exists=True,
-            )
-        ),
-    ] = None,
-    start_date: Date = None,
-    end_date: Date = None,
+    dmp_subset: DMPSubsetLocal | None = None,
+    dmps_start_date: Date = None,
+    dmps_end_date: Date = None,
     log_level: LogLevel = "INFO",
 ):
     """Run the DMP works search, returning candidate matches for each DMP.
@@ -244,13 +259,11 @@ def dmp_works_search_cmd(
         max_concurrent_searches: The maximum number of concurrent searches.
         max_concurrent_shard_requests: The maximum number of shards searched per node.
         client_config: OpenSearch client settings.
-        institutions_file: When supplied only includes DMPs which have an institution in this list.
-        dois_file: When supplied only includes DMPs which have a DOI in this list.
-        start_date: Return DMPs with project start dates on or after this date.
-        end_date: Return DMPs with project start dates on before this date.
+        dmp_subset: Settings for including a subset of DMPs.
+        dmps_start_date: Return DMPs with project start dates on or after this date.
+        dmps_end_date: Return DMPs with project start dates on or before this date.
         log_level: Python log level (e.g., INFO).
     """
-    from dmpworks.dataset_subset import load_dois, load_institutions
     from dmpworks.opensearch.dmp_works_search import dmp_works_search
 
     if client_config is None:
@@ -260,13 +273,7 @@ def dmp_works_search_cmd(
     logging.basicConfig(level=level)
     logging.getLogger("opensearch").setLevel(logging.WARNING)
 
-    # Load institutions and dois subset
-    institutions = None
-    if institutions_file:
-        institutions = load_institutions(institutions_file)
-    dois = None
-    if dois_file:
-        dois = load_dois(dois_file)
+    institutions, dois = load_dmp_subset_local(dmp_subset)
 
     out_dir.mkdir(parents=True, exist_ok=True)
     dmp_works_search(
@@ -286,8 +293,8 @@ def dmp_works_search_cmd(
         max_concurrent_shard_requests=max_concurrent_shard_requests,
         institutions=institutions,
         dois=dois,
-        start_date=start_date,
-        end_date=end_date,
+        start_date=dmps_start_date,
+        end_date=dmps_end_date,
     )
 
 

--- a/python/dmpworks/opensearch/dmp_search.py
+++ b/python/dmpworks/opensearch/dmp_search.py
@@ -38,8 +38,8 @@ def fetch_dmps(
         page_size: The number of results to return per page.
         dois: A list of DOIs to filter by.
         institutions: A list of institutions to filter by.
-        start_date: The start date for the project start range filter.
-        end_date: The end date for the project start range filter.
+        start_date: Return DMPs with project start dates on or after this date.
+        end_date: Return DMPs with project start dates on before this date.
         inner_hits_size: The size of inner hits to return for nested fields.
 
     Yields:

--- a/python/dmpworks/opensearch/dmp_works_search.py
+++ b/python/dmpworks/opensearch/dmp_works_search.py
@@ -87,8 +87,8 @@ def dmp_works_search(
     max_concurrent_shard_requests: int = 12,
     institutions: list[Institution] | None = None,
     dois: list[str] | None = None,
-    start_date: pendulum.Date | None = None,
-    end_date: pendulum.Date | None = None,
+    start_date: pendulum.Date | None = None,  # TODO: Claude rename to dmps_start_date
+    end_date: pendulum.Date | None = None,  # TODO: Claude rename to dmps_end_date
     inner_hits_size: int = 50,
     row_group_size: int = 50_000,
     row_groups_per_file: int = 4,
@@ -112,8 +112,8 @@ def dmp_works_search(
         max_concurrent_shard_requests: The maximum number of concurrent shard requests for msearch.
         institutions: A list of institutions to filter DMPs by.
         dois: A list of DOIs to filter DMPs by.
-        start_date: The start date for the project start range filter.
-        end_date: The end date for the project start range filter.
+        start_date: Return DMPs with project start dates on or after this date.
+        end_date: Return DMPs with project start dates on before this date.
         inner_hits_size: The size of inner hits to return for nested fields.
         row_group_size: Number of rows per Parquet row group.
         row_groups_per_file: Number of row groups per output file before rotating.

--- a/python/dmpworks/opensearch/enrich_dmps.py
+++ b/python/dmpworks/opensearch/enrich_dmps.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import pendulum
 from tqdm import tqdm
@@ -8,7 +11,90 @@ from dmpworks.model.dmp_model import Award, ExternalData
 from dmpworks.opensearch.dmp_search import yield_dmps
 from dmpworks.opensearch.utils import OpenSearchClientConfig, make_opensearch_client
 
+if TYPE_CHECKING:
+    from dmpworks.model.common import Institution
+
 log = logging.getLogger(__name__)
+
+
+def build_enrich_query(
+    institutions: list[Institution] | None = None,
+    dois: list[str] | None = None,
+) -> dict:
+    """Build the OpenSearch query for selecting DMPs to enrich.
+
+    Wraps the existing modification-date script filter with optional institution
+    and DOI subset filters.
+
+    Args:
+        institutions: When supplied only enriches DMPs from these institutions.
+        dois: When supplied only enriches DMPs with these DOIs.
+
+    Returns:
+        dict: The OpenSearch query body.
+    """
+    script_filter = {
+        "script": {
+            "script": {
+                "lang": "painless",
+                "source": """
+                       try {
+                           def modifiedExists = doc['modified'].size() > 0;
+                           def externalUpdatedExists = doc['external_data.updated'].size() > 0;
+
+                           if (!modifiedExists && !externalUpdatedExists) {
+                               return true;
+                           } else if (!externalUpdatedExists) {
+                               return true;
+                           } else if (!modifiedExists) {
+                               return false;
+                           }
+
+                           long modifiedMillis = doc['modified'].value.toInstant().toEpochMilli();
+                           long externalUpdatedMillis = doc['external_data.updated'].value.toInstant().toEpochMilli();
+
+                           return modifiedMillis >= externalUpdatedMillis;
+
+                       } catch (Exception e) {
+                           return false;
+                       }
+                   """,
+            }
+        }
+    }
+
+    subset_filters = []
+    if dois:
+        subset_filters.append({"ids": {"values": dois}})
+    if institutions:
+        institution_queries = []
+        ror_ids = [inst.ror for inst in institutions if inst.ror]
+        if ror_ids:
+            institution_queries.append({"terms": {"institutions.ror": ror_ids}})
+        names = [inst.name for inst in institutions if inst.name]
+        for name in names:
+            institution_queries.append({"match_phrase": {"institutions.name": {"query": name, "slop": 3}}})
+        if institution_queries:
+            subset_filters.append(
+                {
+                    "nested": {
+                        "path": "institutions",
+                        "query": {"bool": {"should": institution_queries, "minimum_should_match": 1}},
+                    }
+                }
+            )
+
+    if subset_filters:
+        return {
+            "query": {
+                "bool": {
+                    "must": [script_filter],
+                    "filter": subset_filters,
+                }
+            }
+        }
+
+    return {"query": script_filter}
 
 
 def enrich_dmps(
@@ -17,6 +103,8 @@ def enrich_dmps(
     page_size: int = 500,
     scroll_time: str = "360m",
     email: str | None = None,
+    institutions: list[Institution] | None = None,
+    dois: list[str] | None = None,
 ):
     """Enrich DMPs with additional metadata from external sources.
 
@@ -26,39 +114,11 @@ def enrich_dmps(
         page_size: The number of DMPs to process per batch.
         scroll_time: The scroll time for the search context.
         email: The email address to use for external API requests.
+        institutions: When supplied only enriches DMPs from these institutions.
+        dois: When supplied only enriches DMPs with these DOIs.
     """
     client = make_opensearch_client(client_config)
-    query = {
-        "query": {
-            "script": {
-                "script": {
-                    "lang": "painless",
-                    "source": """
-                           try {
-                               def modifiedExists = doc['modified'].size() > 0;
-                               def externalUpdatedExists = doc['external_data.updated'].size() > 0;
-                           
-                               if (!modifiedExists && !externalUpdatedExists) {
-                                   return true;
-                               } else if (!externalUpdatedExists) {
-                                   return true;
-                               } else if (!modifiedExists) {
-                                   return false;
-                               }
-
-                               long modifiedMillis = doc['modified'].value.toInstant().toEpochMilli();
-                               long externalUpdatedMillis = doc['external_data.updated'].value.toInstant().toEpochMilli();
-
-                               return modifiedMillis >= externalUpdatedMillis;
-
-                           } catch (Exception e) {
-                               return false;
-                           }
-                       """,
-                }
-            }
-        }
-    }
+    query = build_enrich_query(institutions=institutions, dois=dois)
 
     with (
         tqdm(
@@ -88,8 +148,8 @@ def enrich_dmps(
 
                 # Fetch additional data for each award ID
                 for award_id in award_ids:
-                    dois = fetch_funded_dois(award_id, email=email)
-                    awards.append(Award(funder=fund.funder, award_id=award_id, funded_dois=dois))
+                    funded_dois = fetch_funded_dois(award_id, email=email)
+                    awards.append(Award(funder=fund.funder, award_id=award_id, funded_dois=funded_dois))
 
             log.debug(f"Save additional metadata for DMP: {dmp.doi}")
             external_data = ExternalData(updated=pendulum.now(tz="UTC"), awards=awards).model_dump()

--- a/python/dmpworks/opensearch/sync_dmps.py
+++ b/python/dmpworks/opensearch/sync_dmps.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from contextlib import closing
 import logging
+from typing import TYPE_CHECKING
 
 from opensearchpy.helpers import streaming_bulk
 import pendulum
@@ -15,9 +18,12 @@ from dmpworks.opensearch.utils import OpenSearchClientConfig, make_opensearch_cl
 from dmpworks.transform.dmp import transform_dmp
 from dmpworks.utils import timed
 
+if TYPE_CHECKING:
+    from dmpworks.model.common import Institution
+
 log = logging.getLogger(__name__)
 
-DMPS_QUERY = """
+DMPS_QUERY_TEMPLATE = """
 WITH institutions AS (
   SELECT
     temp.plan_id,
@@ -89,7 +95,7 @@ funding AS (
   FROM (
     SELECT
       pl.id AS plan_id,
-      plf.id AS plan_funding_id,	  
+      plf.id AS plan_funding_id,
       af.name AS funder_name,
       prf.affiliationId AS funder_id,
       prf.funderOpportunityNumber AS funder_opportunity_id,
@@ -100,7 +106,7 @@ funding AS (
     INNER JOIN planFundings plf ON plf.planId = pl.id
     INNER JOIN projectFundings prf ON prf.id = plf.projectFundingId
     LEFT JOIN affiliations af ON af.uri = prf.affiliationId
-    WHERE pl.dmpId IS NOT NULL 
+    WHERE pl.dmpId IS NOT NULL
           AND COALESCE(af.name, prf.affiliationId, prf.funderOpportunityNumber, prf.grantId) IS NOT NULL
   ) AS temp
   GROUP BY temp.plan_id
@@ -136,19 +142,18 @@ SELECT
   pr.abstractText AS abstract_text,
   pr.startDate AS project_start,
   pr.endDate AS project_end,
-  COALESCE(au.authors, '[]') AS authors, 
-  COALESCE(inst.institutions, '[]') AS institutions, 
-  COALESCE(fn.funding, '[]') AS funding, 
-  COALESCE(po.published_outputs, '[]') AS published_outputs 
+  COALESCE(au.authors, '[]') AS authors,
+  COALESCE(inst.institutions, '[]') AS institutions,
+  COALESCE(fn.funding, '[]') AS funding,
+  COALESCE(po.published_outputs, '[]') AS published_outputs
 FROM plans AS pl
 LEFT JOIN projects AS pr ON pr.id = pl.projectId
 LEFT JOIN institutions inst ON inst.plan_id = pl.id
 LEFT JOIN authors au ON au.plan_id = pl.id
 LEFT JOIN funding fn ON fn.plan_id = pl.id
 LEFT JOIN published_outputs po ON po.plan_id = pl.id
-WHERE pl.dmpId IS NOT NULL;
+WHERE pl.dmpId IS NOT NULL
 """
-
 
 DMPS_MAPPING_FILE = "dmps-mapping.json"
 
@@ -159,6 +164,8 @@ def sync_dmps(
     mysql_config: MySQLConfig,
     opensearch_config: OpenSearchClientConfig = None,
     chunk_size: int = 1000,
+    institutions: list[Institution] | None = None,
+    dois: list[str] | None = None,
 ):
     """Syncs the DMPs from the MySQL database to OpenSearch.
 
@@ -167,6 +174,8 @@ def sync_dmps(
         mysql_config: The MySQL configuration.
         opensearch_config: The OpenSearch client configuration.
         chunk_size: The number of DMPs to process per batch.
+        institutions: When supplied only syncs DMPs from these institutions.
+        dois: When supplied only syncs DMPs with these DOIs.
     """
     if opensearch_config is None:
         opensearch_config = OpenSearchClientConfig()
@@ -179,6 +188,7 @@ def sync_dmps(
 
     success_count = 0
     failed_count = 0
+    skipped_count = 0
 
     with closing(
         pymysql.connect(
@@ -191,17 +201,33 @@ def sync_dmps(
         )
     ) as conn:
 
+        def postfix():
+            return {"Success": f"{success_count:,}", "Failed": f"{failed_count:,}", "Skipped": f"{skipped_count:,}"}
+
         def on_validation_error():
             nonlocal failed_count
             failed_count += 1
             pbar.update(1)
-            pbar.set_postfix({"Success": f"{success_count:,}", "Failed": f"{failed_count:,}"})
+            pbar.set_postfix(postfix())
+
+        def on_skipped():
+            nonlocal skipped_count
+            skipped_count += 1
+            pbar.update(1)
+            pbar.set_postfix(postfix())
 
         total_rows = count_dmps(conn)
         with tqdm(total=total_rows, desc="Sync DMPs with OpenSearch", unit="doc") as pbar:
             for ok, item in streaming_bulk(
                 os_client,
-                generate_actions(conn=conn, dmps_index=index_name, on_error=on_validation_error),
+                generate_actions(
+                    conn=conn,
+                    dmps_index=index_name,
+                    on_error=on_validation_error,
+                    on_skipped=on_skipped,
+                    institutions=institutions,
+                    dois=dois,
+                ),
                 chunk_size=chunk_size,
                 raise_on_error=False,
             ):
@@ -213,12 +239,7 @@ def sync_dmps(
                     log.error(f"OpenSearch indexing failed for DMP: {dmp_id}")
 
                 pbar.update(1)
-                pbar.set_postfix(
-                    {
-                        "Success": f"{success_count:,}",
-                        "Failed": f"{failed_count:,}",
-                    }
-                )
+                pbar.set_postfix(postfix())
 
 
 def count_dmps(conn):
@@ -230,8 +251,9 @@ def count_dmps(conn):
     Returns:
         int: The number of DMPs.
     """
+    query = "SELECT COUNT(DISTINCT pl.id) AS total FROM plans pl WHERE pl.dmpId IS NOT NULL;"
     with conn.cursor() as count_cursor:
-        count_cursor.execute("SELECT COUNT(*) AS total FROM plans WHERE dmpId IS NOT NULL;")
+        count_cursor.execute(query)
         result = count_cursor.fetchone()
         return result["total"]
 
@@ -257,23 +279,44 @@ def validate_dmp(dmp: DMPModel) -> None:
         )
 
 
-def generate_actions(*, conn, dmps_index: str, on_error: callable):
+def generate_actions(
+    *,
+    conn,
+    dmps_index: str,
+    on_error: callable,
+    on_skipped: callable,
+    institutions: list[Institution] | None = None,
+    dois: list[str] | None = None,
+):
     """Generate OpenSearch bulk actions from MySQL rows.
 
     Args:
         conn: The MySQL connection.
         dmps_index: The name of the DMPs index.
-        on_error: A callback function to call when an error occurs.
+        on_error: A callback function to call when a validation error occurs.
+        on_skipped: A callback function to call when a DMP is filtered by subset.
+        institutions: When supplied only syncs DMPs from these institutions (matched by ROR ID).
+        dois: When supplied only syncs DMPs with these DOIs.
 
     Yields:
         dict: An OpenSearch bulk action.
     """
+    dois_set = set(dois) if dois else None
+    ror_set = {inst.ror for inst in institutions if inst.ror} if institutions else None
+
     with conn.cursor() as stream_cursor:
-        stream_cursor.execute(DMPS_QUERY)
+        stream_cursor.execute(DMPS_QUERY_TEMPLATE)
         for row in stream_cursor:
             try:
                 dmp = transform_dmp(row)
                 validate_dmp(dmp)
+
+                if dois_set is not None and dmp.doi not in dois_set:
+                    on_skipped()
+                    continue
+                if ror_set is not None and not any(inst.ror in ror_set for inst in dmp.institutions if inst.ror):
+                    on_skipped()
+                    continue
 
                 yield {
                     "_op_type": "update",

--- a/python/dmpworks/transform/cli.py
+++ b/python/dmpworks/transform/cli.py
@@ -1,12 +1,12 @@
 import logging
-import pathlib
-from typing import Annotated, Literal
+from typing import Literal
 
-from cyclopts import App, Parameter, validators
+from cyclopts import App
 
 from dmpworks.cli_utils import (
     CrossrefMetadataTransformConfig,
     DataCiteTransformConfig,
+    DatasetSubsetLocal,
     Directory,
     LogLevel,
     OpenAlexWorksTransformConfig,
@@ -113,30 +113,7 @@ def dataset_subset_cmd(
     dataset: Literal["crossref-metadata", "datacite", "openalex-works"],
     in_dir: Directory,
     out_dir: Directory,
-    institutions_path: Annotated[
-        pathlib.Path,
-        Parameter(
-            validator=validators.Path(
-                dir_okay=False,
-                file_okay=True,
-                exists=True,
-            ),
-            env_var="DATASET_SUBSET_INSTITUTIONS_PATH",
-            help="Path to a list of ROR IDs and institution names. Works authored by researchers from these institutions will be included.",
-        ),
-    ],
-    dois_path: Annotated[
-        pathlib.Path | None,
-        Parameter(
-            validator=validators.Path(
-                dir_okay=False,
-                file_okay=True,
-                exists=True,
-            ),
-            env_var="DATASET_SUBSET_DOIS_PATH",
-            help="Path to a specific list of Work DOIs to include in the subset.",
-        ),
-    ] = None,
+    dataset_subset: DatasetSubsetLocal | None = None,
     log_level: LogLevel = "INFO",
 ):
     """Create a demo dataset.
@@ -145,8 +122,7 @@ def dataset_subset_cmd(
         dataset: The dataset to filter.
         in_dir: Path to the dataset directory (e.g. /path/to/openalex_works).
         out_dir: Path to the output directory (e.g. /path/to/demo_dataset/openalex).
-        institutions_path: Path to a JSON file containing a list of ROR IDs and institution names, e.g. `[{"name": "University of California, San Diego", "ror": "0168r3w48"}]`. Works authored by researchers from these institutions will be included.
-        dois_path: Path to a JSON file with specific list of Work DOIs to include in the subset, e.g. `["10.0000/abc", "10.0000/123"]`.
+        dataset_subset: Settings for filtering the dataset by institutions or DOIs.
         log_level: Python log level.
     """
     from dmpworks.dataset_subset import load_dois, load_institutions
@@ -156,8 +132,14 @@ def dataset_subset_cmd(
     level = logging.getLevelName(log_level)
     setup_multiprocessing_logging(level)
 
-    institutions = load_institutions(institutions_path)
-    dois = load_dois(dois_path) if dois_path is not None else []
+    use_subset = dataset_subset is not None and dataset_subset.enable
+    institutions = []
+    dois = []
+    if use_subset:
+        if dataset_subset.institutions_path is not None:
+            institutions = load_institutions(dataset_subset.institutions_path)
+        if dataset_subset.dois_path is not None:
+            dois = load_dois(dataset_subset.dois_path)
 
     create_dataset_subset(
         dataset=dataset,

--- a/tests/dmpworks/batch/test_cli.py
+++ b/tests/dmpworks/batch/test_cli.py
@@ -399,6 +399,8 @@ class TestOpenSearchCLI:
         mock_enrich_dmps.assert_called_once_with(
             index_name="dmps-index",
             client_config=OpenSearchClientConfig(),
+            bucket_name=None,
+            dmp_subset=None,
         )
 
     def test_dmp_works_search(self, mock_dmp_works_search):

--- a/tests/dmpworks/batch/test_dataset_subset.py
+++ b/tests/dmpworks/batch/test_dataset_subset.py
@@ -4,27 +4,31 @@ from dmpworks.dataset_subset import load_dois, load_institutions
 
 
 def test_load_institutions(tmp_path):
-    """Test Institution objects are loaded correctly."""
+    """Test Institution objects are loaded correctly, with ROR IDs normalised via extract_ror."""
     data = [
-        {"name": "University of Science", "ror": "01234"},
-        {"name": "Institute of Art", "ror": "56789"},
+        {"name": "University of Science", "ror": "https://ror.org/01an7q238"},
+        {"name": "Institute of Art", "ror": "02mhbyk09"},
+        {"name": "No ROR Institution", "ror": None},
+        {"name": None, "ror": None},  # should be excluded
     ]
     f = tmp_path / "institutions.json"
     f.write_text(json.dumps(data))
 
     result = load_institutions(f)
-    assert len(result) == 2
+    assert len(result) == 3
     assert result[0].name == "University of Science"
-    assert result[0].ror == "01234"
+    assert result[0].ror == "01an7q238"
     assert result[1].name == "Institute of Art"
-    assert result[1].ror == "56789"
+    assert result[1].ror == "02mhbyk09"
+    assert result[2].name == "No ROR Institution"
+    assert result[2].ror is None
 
 
 def test_load_dois(tmp_path):
-    """Test that DOIs are loaded correctly"""
-    data = ["10.1234/example.1", "10.5678/example.2"]
+    """Test that DOIs are loaded and normalised via extract_doi, with invalid entries excluded."""
+    data = ["10.1234/example.1", "https://doi.org/10.5678/example.2", "not-a-doi"]
     f = tmp_path / "dois.json"
     f.write_text(json.dumps(data))
 
     result = load_dois(f)
-    assert result == data
+    assert result == ["10.1234/example.1", "10.5678/example.2"]

--- a/tests/dmpworks/batch_submit/test_cli.py
+++ b/tests/dmpworks/batch_submit/test_cli.py
@@ -15,7 +15,7 @@ from dmpworks.batch_submit.cli import (
     ror_cmd,
 )
 from dmpworks.cli_utils import (
-    DatasetSubset,
+    DatasetSubsetAWS,
     RunIdentifiers,
     SQLMeshConfig,
 )
@@ -90,7 +90,7 @@ class TestCrossrefMetadataCmd:
         assert task_defs["transform"].keywords["use_subset"] is False
 
     def test_with_subset_includes_dataset_subset_task(self):
-        ds = DatasetSubset(enable=True, institutions_s3_path="path/institutions.csv")
+        ds = DatasetSubsetAWS(enable=True, institutions_s3_path="path/institutions.csv")
         with (
             patch("dmpworks.batch_submit.jobs.crossref_metadata_download_job") as mock_dl,
             patch("dmpworks.batch_submit.jobs.crossref_metadata_transform_job") as mock_tr,
@@ -116,7 +116,7 @@ class TestCrossrefMetadataCmd:
         assert task_defs["transform"].keywords["use_subset"] is True
 
     def test_disabled_dataset_subset_treated_as_no_subset(self):
-        ds = DatasetSubset(enable=False)
+        ds = DatasetSubsetAWS(enable=False)
         with (
             patch("dmpworks.batch_submit.jobs.crossref_metadata_download_job"),
             patch("dmpworks.batch_submit.jobs.crossref_metadata_transform_job") as mock_tr,
@@ -179,7 +179,7 @@ class TestDataciteCmd:
         assert task_defs["transform"].keywords["use_subset"] is False
 
     def test_with_subset_includes_dataset_subset_task(self):
-        ds = DatasetSubset(enable=True)
+        ds = DatasetSubsetAWS(enable=True)
         with (
             patch("dmpworks.batch_submit.jobs.datacite_download_job"),
             patch("dmpworks.batch_submit.jobs.datacite_transform_job") as mock_tr,
@@ -243,7 +243,7 @@ class TestOpenAlexWorksCmd:
         assert task_defs["transform"].keywords["use_subset"] is False
 
     def test_with_subset_includes_dataset_subset_task(self):
-        ds = DatasetSubset(enable=True, dois_s3_path="path/dois.csv")
+        ds = DatasetSubsetAWS(enable=True, dois_s3_path="path/dois.csv")
         with (
             patch("dmpworks.batch_submit.jobs.openalex_works_download_job"),
             patch("dmpworks.batch_submit.jobs.openalex_works_transform_job") as mock_tr,

--- a/tests/dmpworks/batch_submit/test_jobs.py
+++ b/tests/dmpworks/batch_submit/test_jobs.py
@@ -33,8 +33,8 @@ from dmpworks.batch_submit.jobs import (
 from dmpworks.cli_utils import (
     CrossrefMetadataTransformConfig,
     DataCiteTransformConfig,
-    DatasetSubset,
-    DMPSubset,
+    DatasetSubsetAWS,
+    DMPSubsetAWS,
     OpenAlexWorksTransformConfig,
     OpenSearchClientConfig,
     OpenSearchSyncConfig,
@@ -232,7 +232,7 @@ class TestRorDownloadJob:
 
 class TestDatasetSubsetJob:
     def test_submit_job_args(self, mock_submit):
-        ds = DatasetSubset(enable=True, institutions_s3_path="path/institutions.csv")
+        ds = DatasetSubsetAWS(enable=True, institutions_s3_path="path/institutions.csv")
         dataset_subset_job(
             env="dev",
             bucket_name="my-bucket",
@@ -249,7 +249,7 @@ class TestDatasetSubsetJob:
         assert kwargs["memory"] == LARGE_MEMORY
 
     def test_environment_with_all_subset_fields(self, mock_submit):
-        ds = DatasetSubset(
+        ds = DatasetSubsetAWS(
             enable=True,
             institutions_s3_path="path/institutions.csv",
             dois_s3_path="path/dois.csv",
@@ -273,7 +273,7 @@ class TestDatasetSubsetJob:
         }
 
     def test_environment_none_subset_fields_filtered(self, mock_submit):
-        ds = DatasetSubset(enable=False)
+        ds = DatasetSubsetAWS(enable=False)
         dataset_subset_job(
             env="dev",
             bucket_name="my-bucket",
@@ -287,7 +287,7 @@ class TestDatasetSubsetJob:
         assert "DATASET_SUBSET_DOIS_S3_PATH" not in env
 
     def test_depends_on_passed(self, mock_submit):
-        ds = DatasetSubset(enable=True)
+        ds = DatasetSubsetAWS(enable=True)
         depends = [{"jobId": "prior-job"}]
         dataset_subset_job(
             env="dev",
@@ -830,24 +830,26 @@ class TestSubmitSyncWorksJob:
 
 class TestSubmitSyncDmpsJob:
     def test_uses_database_job_definition(self, mock_submit):
-        submit_sync_dmps_job(env="dev", run_id_dmps="dmps-run-1")
+        submit_sync_dmps_job(env="dev", bucket_name="my-bucket", run_id_dmps="dmps-run-1")
         job_def = mock_submit.call_args.kwargs["job_definition"]
         assert job_def == database_job_definition("dev")
         assert job_def != standard_job_definition("dev")
 
     def test_command(self, mock_submit):
-        submit_sync_dmps_job(env="dev", run_id_dmps="dmps-run-1", index_name="my-dmps-index")
-        assert "sync-dmps $INDEX_NAME" in mock_submit.call_args.kwargs["command"]
+        submit_sync_dmps_job(env="dev", bucket_name="my-bucket", run_id_dmps="dmps-run-1", index_name="my-dmps-index")
+        assert "sync-dmps $BUCKET_NAME $INDEX_NAME" in mock_submit.call_args.kwargs["command"]
 
     def test_environment(self, mock_submit):
         submit_sync_dmps_job(
             env="dev",
+            bucket_name="my-bucket",
             run_id_dmps="dmps-run-1",
             index_name="my-dmps-index",
             os_client_config=AWS_OS_CLIENT_CONFIG,
             os_sync_config=OpenSearchSyncConfig(),
         )
         expected = {
+            "BUCKET_NAME": "my-bucket",
             "INDEX_NAME": "my-dmps-index",
             "TQDM_POSITION": TQDM_POSITION,
             "TQDM_MININTERVAL": TQDM_MININTERVAL,
@@ -858,27 +860,29 @@ class TestSubmitSyncDmpsJob:
 
     def test_depends_on_passed(self, mock_submit):
         depends = [{"jobId": "prior"}]
-        submit_sync_dmps_job(env="dev", run_id_dmps="dmps-run-1", depends_on=depends)
+        submit_sync_dmps_job(env="dev", bucket_name="my-bucket", run_id_dmps="dmps-run-1", depends_on=depends)
         assert mock_submit.call_args.kwargs["depends_on"] == depends
 
 
 class TestSubmitEnrichDmpsJob:
     def test_uses_standard_job_definition(self, mock_submit):
-        submit_enrich_dmps_job(env="dev", run_id_dmps="dmps-run-1")
+        submit_enrich_dmps_job(env="dev", bucket_name="my-bucket", run_id_dmps="dmps-run-1")
         assert mock_submit.call_args.kwargs["job_definition"] == standard_job_definition("dev")
 
     def test_command(self, mock_submit):
-        submit_enrich_dmps_job(env="dev", run_id_dmps="dmps-run-1", index_name="my-dmps-index")
-        assert "enrich-dmps $INDEX_NAME" in mock_submit.call_args.kwargs["command"]
+        submit_enrich_dmps_job(env="dev", bucket_name="my-bucket", run_id_dmps="dmps-run-1", index_name="my-dmps-index")
+        assert "enrich-dmps $INDEX_NAME --bucket-name $BUCKET_NAME" in mock_submit.call_args.kwargs["command"]
 
     def test_environment(self, mock_submit):
         submit_enrich_dmps_job(
             env="dev",
+            bucket_name="my-bucket",
             run_id_dmps="dmps-run-1",
             index_name="my-dmps-index",
             os_client_config=AWS_OS_CLIENT_CONFIG,
         )
         expected = {
+            "BUCKET_NAME": "my-bucket",
             "INDEX_NAME": "my-dmps-index",
             "TQDM_POSITION": TQDM_POSITION,
             "TQDM_MININTERVAL": TQDM_MININTERVAL,
@@ -888,7 +892,7 @@ class TestSubmitEnrichDmpsJob:
 
     def test_depends_on_passed(self, mock_submit):
         depends = [{"jobId": "prior"}]
-        submit_enrich_dmps_job(env="dev", run_id_dmps="dmps-run-1", depends_on=depends)
+        submit_enrich_dmps_job(env="dev", bucket_name="my-bucket", run_id_dmps="dmps-run-1", depends_on=depends)
         assert mock_submit.call_args.kwargs["depends_on"] == depends
 
 
@@ -933,7 +937,7 @@ class TestSubmitDmpWorksSearchJob:
         assert env_as_dict(mock_submit.call_args) == expected
 
     def test_environment_with_dmp_subset(self, mock_submit):
-        ds = DMPSubset(enable=True, dois_s3_path="path/dois.csv", institutions_s3_path="path/inst.csv")
+        ds = DMPSubsetAWS(enable=True, dois_s3_path="path/dois.csv", institutions_s3_path="path/inst.csv")
         submit_dmp_works_search_job(
             env="dev",
             bucket_name="my-bucket",

--- a/tests/dmpworks/opensearch/test_cli.py
+++ b/tests/dmpworks/opensearch/test_cli.py
@@ -103,6 +103,8 @@ class TestOpenSearchCLI:
         mock_enrich_dmps.assert_called_once_with(
             "dmps-index",
             OpenSearchClientConfig(),
+            institutions=None,
+            dois=None,
         )
 
     @pytest.fixture

--- a/tests/dmpworks/transform/test_cli.py
+++ b/tests/dmpworks/transform/test_cli.py
@@ -102,8 +102,6 @@ class TestTransformCLI:
 
         in_dir.mkdir()
         out_dir.mkdir()
-
-        # Cyclopts validators require exists=True for file paths
         inst_path.touch()
         dois_path.touch()
 
@@ -114,8 +112,10 @@ class TestTransformCLI:
                 "openalex-works",
                 str(in_dir),
                 str(out_dir),
+                "--dataset-subset.enable",
+                "--dataset-subset.institutions-path",
                 str(inst_path),
-                "--dois-path",
+                "--dataset-subset.dois-path",
                 str(dois_path),
             ]
         )
@@ -152,6 +152,8 @@ class TestTransformCLI:
                 "datacite",
                 str(in_dir),
                 str(out_dir),
+                "--dataset-subset.enable",
+                "--dataset-subset.institutions-path",
                 str(inst_path),
             ]
         )


### PR DESCRIPTION
Make the works subset and DMPs subset feature the same across local runs and AWS (aside from that in AWS the files are stored in S3). For DMPs they now apply to the first three stages of the process DMPs pipeine (sync-dmps, enrich-dmps and dmps-work-search). See `.env.local.example` and `.env.aws.example` for how these are configured.