### PR TITLE
Fix tqdm printing too frequently in AWS Batch

### DIFF
--- a/python/dmpworks/opensearch/sync.py
+++ b/python/dmpworks/opensearch/sync.py
@@ -197,7 +197,7 @@ def update_progress_bar(
     postfix = {"Success": f"{success_count:,}", "Fail": f"{failure_count:,}"}
     if postfix_extra:
         postfix.update(postfix_extra)
-    pbar.set_postfix(postfix)
+    pbar.set_postfix(postfix, refresh=False)
     return new_total
 
 

--- a/python/dmpworks/opensearch/sync_dmps.py
+++ b/python/dmpworks/opensearch/sync_dmps.py
@@ -216,13 +216,13 @@ def sync_dmps(
             nonlocal failed_count
             failed_count += 1
             pbar.update(1)
-            pbar.set_postfix(postfix())
+            pbar.set_postfix(postfix(), refresh=False)
 
         def on_skipped():
             nonlocal skipped_count
             skipped_count += 1
             pbar.update(1)
-            pbar.set_postfix(postfix())
+            pbar.set_postfix(postfix(), refresh=False)
 
         total_rows = count_dmps(conn)
         with tqdm(total=total_rows, desc="Sync DMPs with OpenSearch", unit="doc") as pbar:
@@ -247,7 +247,7 @@ def sync_dmps(
                     log.error(f"OpenSearch indexing failed for DMP: {dmp_id}")
 
                 pbar.update(1)
-                pbar.set_postfix(postfix())
+                pbar.set_postfix(postfix(), refresh=False)
 
 
 def count_dmps(conn):

--- a/python/dmpworks/transform/dataset_subset.py
+++ b/python/dmpworks/transform/dataset_subset.py
@@ -231,7 +231,7 @@ def create_dataset_subset(
                         log.exception("Error getting future")
                         total_errors += 1
                     pbar.update(1)
-                    pbar.set_postfix({"Filtered": f"{total_filtered:,}", "Errors": f"{total_errors:,}"})
+                    pbar.set_postfix({"Filtered": f"{total_filtered:,}", "Errors": f"{total_errors:,}"}, refresh=False)
     except KeyboardInterrupt:
         log.info("Shutting down...")
         executor.shutdown(wait=True, cancel_futures=True)


### PR DESCRIPTION
Some tqdm progress bars were printing too frequently despite TQDM_POSITION = "-1" and
TQDM_MININTERVAL = "120". It turns out that `pbar.set_postfix(postfix())` forces a refresh by default, so needed to change to `pbar.set_postfix(postfix(), refresh=False)`.