### PR TITLE
Write out empty jsonl.gz file when there are no works search results

### DIFF
--- a/python/dmpworks/utils.py
+++ b/python/dmpworks/utils.py
@@ -461,6 +461,11 @@ class JsonlGzBatchWriter:
         if self._file is not None:
             self._file.close()
             self._file = None
+        elif self._file_index == 0:
+            # No records were written; create an empty .jsonl.gz so downstream uploads succeed
+            path = self.output_dir / f"{self.file_prefix}_{self._file_index:04d}.jsonl.gz"
+            with gzip.open(path, mode="wb"):
+                pass
 
     def __enter__(self):
         """Enter the context manager.

--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,6 @@
   "schedule": [
     "* 0-2 * * 0,3"
   ],
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "behind-base-branch",
+  "updateNotScheduled": true
 }

--- a/tests/dmpworks/test_utils.py
+++ b/tests/dmpworks/test_utils.py
@@ -228,11 +228,14 @@ class TestJsonlGzBatchWriter:
         assert "out_0000.jsonl.gz" in names
         assert "out_0001.jsonl.gz" in names
 
-    def test_no_file_written_for_empty_input(self, tmp_path: pathlib.Path):
+    def test_empty_file_written_for_no_records(self, tmp_path: pathlib.Path):
         with JsonlGzBatchWriter(output_dir=tmp_path, records_per_file=100):
             pass
 
-        assert list(tmp_path.glob("*.jsonl.gz")) == []
+        files = sorted(tmp_path.glob("*.jsonl.gz"))
+        assert len(files) == 1
+        assert files[0].name == "matches_0000.jsonl.gz"
+        assert read_jsonl_gz(files[0]) == []
 
     def test_nested_data_preserved(self, tmp_path: pathlib.Path):
         record = {"dmpDoi": "10.1234/abc", "works": [{"doi": "10.5678/w1", "score": 0.9}]}


### PR DESCRIPTION
Daily DMP works search was failing on daily run when there were no DMPs with updates, so write out empty jsonl.gz file so that the current and next AWS Batch jobs don't crash.

Add `"updateNotScheduled": true` for renovate so that already open PRs can be rebased straight away.