### PR TITLE
Demo updates

### DIFF
--- a/bin/run-rank-metrics.sh
+++ b/bin/run-rank-metrics.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <ground_truth_file> <output_dir>" >&2
+  echo "" >&2
+  echo "  <ground_truth_file>  CSV of (dmp_doi,work_doi,status) judgements" >&2
+  echo "  <output_dir>         Directory for metrics CSVs. Subdirectories" >&2
+  echo "                       no_awards/, awards/, relations/ are created." >&2
+  exit 1
+fi
+
+GROUND_TRUTH_FILE="$1"
+OUTPUT_DIR="$2"
+
+if [ ! -f "${GROUND_TRUTH_FILE}" ]; then
+  echo "Error: ground truth file '${GROUND_TRUTH_FILE}' does not exist" >&2
+  exit 1
+fi
+
+export OPENSEARCH_PORT=8080
+TRUE_POSITIVE_OUTPUTS="${OUTPUT_DIR}/awards/tp_outputs.csv"
+
+mkdir -p \
+  "${OUTPUT_DIR}/no_awards" \
+  "${OUTPUT_DIR}/awards" \
+  "${OUTPUT_DIR}/relations"
+
+# 1. No awards / no identifiers / no relations.
+#    On: authors, institutions, funders, content.
+dmpworks opensearch rank-metrics \
+  "${GROUND_TRUTH_FILE}" \
+  dmps-index \
+  works-index \
+  "${OUTPUT_DIR}/no_awards/metrics.csv" \
+  --max-results=100 \
+  --ks=10 20 100 \
+  --disable-features relations awards funded_dois
+
+# 2. Add funded_dois + awards back in; still no relations.
+#    On: funded_dois, authors, institutions, funders, awards, content.
+#    Also writes the true-positive outputs that the relations run will inject.
+dmpworks opensearch rank-metrics \
+  "${GROUND_TRUTH_FILE}" \
+  dmps-index \
+  works-index \
+  "${OUTPUT_DIR}/awards/metrics.csv" \
+  --max-results=100 \
+  --ks=10 20 100 \
+  --disable-features relations \
+  --true-positive-published-outputs-file="${TRUE_POSITIVE_OUTPUTS}"
+
+# 3. Relations test: everything on, relations driven by the injected TP set from run 2.
+dmpworks opensearch rank-metrics \
+  "${GROUND_TRUTH_FILE}" \
+  dmps-index \
+  works-index \
+  "${OUTPUT_DIR}/relations/metrics.csv" \
+  --max-results=100 \
+  --ks=10 20 100 \
+  --inject-published-outputs-file="${TRUE_POSITIVE_OUTPUTS}"

--- a/docs/aws/architecture.md
+++ b/docs/aws/architecture.md
@@ -54,6 +54,65 @@ flowchart LR
 
 ## Runtime resource flow
 
+Three workflows share S3, OpenSearch, and the DMP Tool database:
+
+```mermaid
+flowchart TB
+    %% Triggers
+    T1([Mon-Fri 08:00]):::trigger
+    T2([2nd Mon 09:00]):::trigger
+    T3([Mon-Fri 20:00]):::trigger
+
+    VC[Version checker]
+
+    subgraph INGEST ["① Dataset Ingest — per new release"]
+        direction LR
+        DL[Download] --> SB[Subset<br/>optional] --> TF[Transform]
+    end
+
+    subgraph WORKS ["② Process Works — monthly"]
+        direction LR
+        RDY{5 datasets<br/>ready?} --> SM[SQLMesh<br/>build index] --> SW[Sync works<br/>to OpenSearch]
+    end
+
+    subgraph DMPS ["③ Process DMPs — daily, or after ②"]
+        direction LR
+        SD[Sync DMPs] --> ED["Enrich<br/>NSF · NIH"] --> DWS[Works search] --> MRW[Merge<br/>related works]
+    end
+
+    %% Shared stores
+    SRC[("Upstream<br/>datasets")]:::store
+    S3[("S3 Parquet")]:::store
+    OS[("OpenSearch<br/>works + dmps")]:::store
+    DB[("DMP Tool<br/>MySQL")]:::store
+
+    %% Trigger edges
+    T1 --> VC
+    T2 --> RDY
+    T3 --> SD
+
+    %% Data flow
+    SRC -->|check version| VC
+    VC -->|start per new release| DL
+    SRC --> DL
+    TF --> S3
+    S3 --> SM
+    SW --> OS
+    DB --> SD
+    SD --> OS
+    OS --> DWS
+    MRW --> DB
+
+    %% Cross-workflow handoffs
+    TF -. checkpoint .-> RDY
+    SW -. async trigger .-> SD
+
+    classDef trigger fill:#fef3c7,stroke:#b45309;
+    classDef store fill:#fff,stroke:#333;
+```
+
+The same pipeline mapped to AWS resources:
+
 ```mermaid
 flowchart TD
     subgraph triggers ["EventBridge"]

--- a/python/dmpworks/cli.py
+++ b/python/dmpworks/cli.py
@@ -42,7 +42,7 @@ def meta(
         env_file: Path to a .env file to load before executing the command.
     """
     if env_file.exists():
-        load_dotenv(dotenv_path=env_file, override=True)
+        load_dotenv(dotenv_path=env_file, override=False)
     cli(tokens)
 
 

--- a/python/dmpworks/cli_utils.py
+++ b/python/dmpworks/cli_utils.py
@@ -163,7 +163,16 @@ LogLevel = Annotated[
     Parameter(help="Python log level"),
 ]
 Date = Annotated[pendulum.Date | None, Parameter(converter=parse_date)]
-QueryBuilder = Literal["build_dmp_works_search_baseline_query", "build_dmp_works_search_candidate_query"]
+QueryBuilder = Literal["build_dmp_works_search_baseline_query"]
+QueryFeature = Literal[
+    "funded_dois",
+    "authors",
+    "institutions",
+    "funders",
+    "awards",
+    "content",
+    "relations",
+]
 
 
 @dataclass

--- a/python/dmpworks/dmsp/cli.py
+++ b/python/dmpworks/dmsp/cli.py
@@ -2,6 +2,8 @@ import logging
 import pathlib
 from typing import Annotated
 
+log = logging.getLogger(__name__)
+
 from cyclopts import App, Parameter, validators
 
 from dmpworks.cli_utils import LogLevel, MergeRelatedWorksConfig, MySQLConfig
@@ -65,6 +67,13 @@ def load_ground_truth_related_works(
 
     level = logging.getLevelName(log_level)
     logging.basicConfig(level=level)
+
+    log.info(
+        f"MySQL: host={mysql_config.mysql_host}, port={mysql_config.mysql_tcp_port}, user={mysql_config.mysql_user}, database={mysql_config.mysql_database}"
+    )
+    log.info(
+        f"OpenSearch: host={opensearch_config.host}, port={opensearch_config.port}, use_ssl={opensearch_config.use_ssl}, verify_certs={opensearch_config.verify_certs}, auth_type={opensearch_config.auth_type}, username={opensearch_config.username}, aws_region={opensearch_config.aws_region}, aws_service={opensearch_config.aws_service}"
+    )
 
     conn = make_connection(mysql_config)
     os_client = make_opensearch_client(opensearch_config)

--- a/python/dmpworks/dmsp/cli.py
+++ b/python/dmpworks/dmsp/cli.py
@@ -2,12 +2,12 @@ import logging
 import pathlib
 from typing import Annotated
 
-log = logging.getLogger(__name__)
-
 from cyclopts import App, Parameter, validators
 
 from dmpworks.cli_utils import LogLevel, MergeRelatedWorksConfig, MySQLConfig
 from dmpworks.opensearch.utils import OpenSearchClientConfig
+
+log = logging.getLogger(__name__)
 
 app = App(name="dmsp", help="Utilities for the DMSP database.")
 related_works_app = App(name="related-works", help="DMSP related works utilities.")

--- a/python/dmpworks/dmsp/ground_truth.py
+++ b/python/dmpworks/dmsp/ground_truth.py
@@ -22,18 +22,18 @@ def read_related_works_csv(file_path: pathlib.Path) -> list[RelatedWorkReference
 
         for i, row in enumerate(reader, start=2):
             plan_id = row.get("plan_id", "").strip() or None
-            dmp_id = row.get("dmp_id", "").strip() or None
+            dmp_doi = row.get("dmp_doi", "").strip() or None
             work_doi = row.get("work_doi", "").strip() or None
 
             if not work_doi:
                 log.warning(f"Row {i}: Skipped (Missing 'work_doi')")
                 continue
 
-            if not plan_id and not dmp_id:
-                log.warning(f"Row {i}: Skipped (Both 'plan_id' and 'dmp_id' are missing)")
+            if not plan_id and not dmp_doi:
+                log.warning(f"Row {i}: Skipped (Both 'plan_id' and 'dmp_doi' are missing)")
                 continue
 
-            results.append(RelatedWorkReference(plan_id=plan_id, dmp_id=dmp_id, work_doi=work_doi))
+            results.append(RelatedWorkReference(plan_id=plan_id, dmp_id=dmp_doi, work_doi=work_doi))
 
     log.info("Read %d ground truth records from %s.", len(results), file_path)
     return results

--- a/python/dmpworks/model/dmp_model.py
+++ b/python/dmpworks/model/dmp_model.py
@@ -139,12 +139,14 @@ class FundingItem(BaseModel):
         funding_opportunity_id: The funding opportunity ID.
         status: The status of the funding.
         award_id: The award ID.
+        funder_project_number: The funder's internal project number.
     """
 
     funder: Funder | None
     funding_opportunity_id: str | None
     status: str | None
     award_id: str | None
+    funder_project_number: str | None
 
 
 class ExternalData(BaseModel):

--- a/python/dmpworks/opensearch/cli.py
+++ b/python/dmpworks/opensearch/cli.py
@@ -13,6 +13,7 @@ from dmpworks.cli_utils import (
     OpenSearchClientConfig,
     OpenSearchSyncConfig,
     QueryBuilder,
+    QueryFeature,
 )
 from dmpworks.opensearch.cli_roles import app as roles_app
 
@@ -319,6 +320,27 @@ def rank_metrics_cmd(
     include_named_queries_score: bool = True,
     inner_hits_size: int = 50,
     ks: Annotated[list[int] | None, Parameter(consume_multiple=True)] = None,
+    inject_published_outputs_file: Annotated[
+        pathlib.Path | None,
+        Parameter(
+            validator=validators.Path(
+                dir_okay=False,
+                file_okay=True,
+                exists=True,
+            )
+        ),
+    ] = None,
+    true_positive_published_outputs_file: Annotated[
+        pathlib.Path | None,
+        Parameter(
+            validator=validators.Path(
+                dir_okay=False,
+                file_okay=True,
+                exists=False,
+            )
+        ),
+    ] = None,
+    disable_features: Annotated[list[QueryFeature] | None, Parameter(consume_multiple=True)] = None,
     log_level: LogLevel = "INFO",
 ):
     """Compute ranking metrics for baseline or re-ranked search results.
@@ -338,8 +360,12 @@ def rank_metrics_cmd(
         include_named_queries_score: Whether to include named query scores in the search response.
         inner_hits_size: Maximum number of inner hits returned for each matched work.
         ks: The top K breakpoints to compute for each metric.
+        inject_published_outputs_file: Path to a CSV (dmp_doi,work_doi columns) defining the published_outputs used during search. When set, this file is the full anchor spec: DMPs listed get injected anchors, DMPs not listed get an empty anchor set. Used to drive the DMP relations feature from a controlled anchor set during benchmarking.
+        true_positive_published_outputs_file: When set, write a CSV of dmp_doi,work_doi pairs for returned works that are also in the ground truth. The output can be fed back in via inject_published_outputs_file on a subsequent run.
+        disable_features: Features to disable in the baseline query for ablation studies. All features are enabled by default. Valid values: funded_dois, authors, institutions, funders, awards, content, relations.
         log_level: Python log level (e.g., INFO).
     """
+    from dmpworks.opensearch.query_builder import QueryFeatures
     from dmpworks.opensearch.rank_metrics import related_works_calculate_metrics
 
     if client_config is None:
@@ -348,6 +374,8 @@ def rank_metrics_cmd(
     level = logging.getLevelName(log_level)
     logging.basicConfig(level=level)
     logging.getLogger("opensearch").setLevel(logging.WARNING)
+
+    features = QueryFeatures(**dict.fromkeys(disable_features, False)) if disable_features else QueryFeatures()
 
     related_works_calculate_metrics(
         ground_truth_file,
@@ -364,6 +392,9 @@ def rank_metrics_cmd(
         batch_size=batch_size,
         max_results=max_results,
         ks=ks,
+        inject_published_outputs_file=inject_published_outputs_file,
+        true_positive_published_outputs_file=true_positive_published_outputs_file,
+        features=features,
     )
 
 

--- a/python/dmpworks/opensearch/enrich_dmps.py
+++ b/python/dmpworks/opensearch/enrich_dmps.py
@@ -141,10 +141,11 @@ def enrich_dmps(
             log.debug(f"Fetch additional metadata for DMP: {dmp.doi}")
             awards = []
             for fund in dmp.funding:
-                # Parse Award IDs, which can be found in both funding_opportunity_id
-                # and award_id
+                # Parse Award IDs, which can be found in funding_opportunity_id,
+                # award_id, and funder_project_number
                 award_ids = parse_award_text(fund.funder.ror, fund.funding_opportunity_id)
                 award_ids.extend(parse_award_text(fund.funder.ror, fund.award_id))
+                award_ids.extend(parse_award_text(fund.funder.ror, fund.funder_project_number))
                 award_ids = set(award_ids)
 
                 # Fetch additional data for each award ID

--- a/python/dmpworks/opensearch/mappings/dmps-mapping.json
+++ b/python/dmpworks/opensearch/mappings/dmps-mapping.json
@@ -182,6 +182,10 @@
           "award_id": {
             "type": "keyword",
             "normalizer": "lowercase"
+          },
+          "funder_project_number": {
+            "type": "keyword",
+            "normalizer": "lowercase"
           }
         }
       },

--- a/python/dmpworks/opensearch/query_builder.py
+++ b/python/dmpworks/opensearch/query_builder.py
@@ -1,12 +1,38 @@
 from collections.abc import Callable
 import copy
+from dataclasses import dataclass
+import logging
 
 import pendulum
 
 from dmpworks.model.common import Institution
-from dmpworks.model.dmp_model import Award, DMPModel
+from dmpworks.model.dmp_model import Award, DMPModel, FundingItem
+
+log = logging.getLogger(__name__)
 
 MIN_START_DATE = pendulum.date(1990, 1, 1)
+
+
+@dataclass(frozen=True)
+class QueryFeatures:
+    """Toggles for features emitted by the baseline query. All on by default.
+
+    Disabling a feature causes its clause to be omitted from the query. Used
+    for ablation studies run via the rank-metrics CLI; production search runs
+    with defaults.
+    """
+
+    funded_dois: bool = True
+    authors: bool = True
+    institutions: bool = True
+    funders: bool = True
+    awards: bool = True
+    content: bool = True
+    relations: bool = True
+
+    def disabled_names(self) -> list[str]:
+        """Return the names of disabled features, sorted."""
+        return sorted(f for f, v in self.__dict__.items() if not v)
 
 
 def get_query_builder(name: str) -> Callable[[DMPModel, int, int, int], dict]:
@@ -23,7 +49,6 @@ def get_query_builder(name: str) -> Callable[[DMPModel, int, int, int], dict]:
     """
     query_builders = {
         "build_dmp_works_search_baseline_query": build_dmp_works_search_baseline_query,
-        "build_dmp_works_search_candidate_query": build_dmp_works_search_candidate_query,
     }
     if name not in query_builders:
         raise ValueError(f"Unknown query builder name: {name}")
@@ -133,7 +158,12 @@ def make_content(dmp: DMPModel) -> str | None:
 
 
 def build_dmp_works_search_baseline_query(
-    dmp: DMPModel, max_results: int, project_end_buffer_years: int, inner_hits_size: int
+    dmp: DMPModel,
+    max_results: int,
+    project_end_buffer_years: int,
+    inner_hits_size: int,
+    *,
+    features: QueryFeatures | None = None,
 ) -> dict:
     """Baseline DMP works search query using manually tuned weights.
 
@@ -142,15 +172,20 @@ def build_dmp_works_search_baseline_query(
         max_results: The maximum number of results to return.
         project_end_buffer_years: The number of years to buffer the project end date.
         inner_hits_size: The size of inner hits to return for nested fields.
+        features: Per-feature toggles. Disabled features omit their clause from the query.
+            Defaults to all features on.
 
     Returns:
-        dict: The OpenSearch query.
+        dict: The OpenSearch query. When every must-clause feature is disabled or produces
+        no clauses, OpenSearch returns zero hits for this DMP (an empty ``bool.should`` with
+        ``minimum_should_match: 1`` matches nothing).
     """
+    features = features if features is not None else QueryFeatures()
     must = []
     should = []
 
     # Funded DOIs
-    if dmp.funded_dois:
+    if features.funded_dois and dmp.funded_dois:
         must.append(
             {
                 "constant_score": {
@@ -164,58 +199,69 @@ def build_dmp_works_search_baseline_query(
         )
 
     # Authors
-    authors = build_entity_query(
-        "authors",
-        "authors.orcid",
-        "authors.full",
-        dmp.authors,
-        lambda author: author.orcid,
-        lambda author: author.surname,
-        inner_hits_size=inner_hits_size,
-        name_slop=None,
-    )
-    if authors is not None:
-        must.append(authors)
+    if features.authors:
+        authors = build_entity_query(
+            "authors",
+            "authors.orcid",
+            "authors.full",
+            dmp.authors,
+            lambda author: author.orcid,
+            lambda author: author.surname,
+            inner_hits_size=inner_hits_size,
+            name_slop=None,
+        )
+        if authors is not None:
+            must.append(authors)
 
     # Institutions
-    institutions = build_entity_query(
-        "institutions",
-        "institutions.ror",
-        "institutions.name",
-        dmp.institutions,
-        lambda inst: inst.ror,
-        lambda inst: inst.name,
-        inner_hits_size=inner_hits_size,
-        name_slop=3,
-    )
-    if institutions is not None:
-        should.append(institutions)
+    if features.institutions:
+        institutions = build_entity_query(
+            "institutions",
+            "institutions.ror",
+            "institutions.name",
+            dmp.institutions,
+            lambda inst: inst.ror,
+            lambda inst: inst.name,
+            inner_hits_size=inner_hits_size,
+            name_slop=3,
+        )
+        if institutions is not None:
+            should.append(institutions)
 
     # Funders
-    funders = build_entity_query(
-        "funders",
-        "funders.ror",
-        "funders.name",
-        dmp.funding,
-        lambda fund: fund.funder.ror,
-        lambda fund: fund.funder.name,
-        inner_hits_size=inner_hits_size,
-        name_slop=3,
-    )
-    if funders is not None:
-        should.append(funders)
+    if features.funders:
+        funders = build_entity_query(
+            "funders",
+            "funders.ror",
+            "funders.name",
+            dmp.funding,
+            lambda fund: fund.funder.ror,
+            lambda fund: fund.funder.name,
+            inner_hits_size=inner_hits_size,
+            name_slop=3,
+        )
+        if funders is not None:
+            should.append(funders)
 
-    # Awards
-    awards = build_awards_query(
-        "awards",
-        dmp.external_data.awards,
-        inner_hits_size=inner_hits_size,
-    )
-    if awards is not None:
-        must.append(awards)
+    # Awards (fall back to raw funding identifiers when no parsed awards available)
+    if features.awards:
+        if dmp.external_data.awards:
+            awards = build_awards_query(
+                "awards",
+                dmp.external_data.awards,
+                inner_hits_size=inner_hits_size,
+            )
+        else:
+            awards = build_raw_awards_query(
+                "awards",
+                dmp.funding,
+                inner_hits_size=inner_hits_size,
+            )
+        if awards is not None:
+            must.append(awards)
 
     # Title and abstract
-    content = make_content(dmp)
+    content = make_content(dmp) if features.content else None
     if content:
         should.append(
             {
@@ -229,41 +275,48 @@ def build_dmp_works_search_baseline_query(
         )
 
     # Relations
-    # Intra work DOIs are the same core work, so they get a high rank
+    # Intra work DOIs are the same core work, so they get a high rank.
     # These are appended to must because if one of these matches it is almost
     # certainly a match.
-    published_outputs = dmp.published_outputs if dmp.published_outputs is not None else []
-    intra_work_dois = build_relations_query(
-        "relations.intra_work_dois",
-        "relations.intra_work_dois.doi",
-        [work.doi for work in published_outputs],
-        boost=10.0,
-    )
-    if intra_work_dois is not None:
-        must.append(intra_work_dois)
+    if features.relations:
+        published_outputs = dmp.published_outputs if dmp.published_outputs is not None else []
+        intra_work_dois = build_relations_query(
+            "relations.intra_work_dois",
+            "relations.intra_work_dois.doi",
+            [work.doi for work in published_outputs],
+            boost=10.0,
+        )
+        if intra_work_dois is not None:
+            must.append(intra_work_dois)
 
-    # Inter work DOIs with relation types that can be used for linking works
-    # published as a part of the same project. E.g. a supplement rather than
-    # a citation.
-    possible_shared_project_dois = build_relations_query(
-        "relations.possible_shared_project_dois",
-        "relations.possible_shared_project_dois.doi",
-        [work.doi for work in published_outputs],
-        boost=5.0,
-    )
-    if possible_shared_project_dois is not None:
-        must.append(possible_shared_project_dois)
+        # Inter work DOIs with relation types that can be used for linking works
+        # published as a part of the same project. E.g. a supplement rather than
+        # a citation.
+        possible_shared_project_dois = build_relations_query(
+            "relations.possible_shared_project_dois",
+            "relations.possible_shared_project_dois.doi",
+            [work.doi for work in published_outputs],
+            boost=5.0,
+        )
+        if possible_shared_project_dois is not None:
+            must.append(possible_shared_project_dois)
 
-    # Dataset citations, these are any kind of citation of a dataset, but still
-    # could be useful information, so have ranked lower than the above two.
-    dataset_citation_dois = build_relations_query(
-        "relations.dataset_citation_dois",
-        "relations.dataset_citation_dois.doi",
-        [work.doi for work in published_outputs],
-        boost=2.5,
-    )
-    if dataset_citation_dois is not None:
-        must.append(dataset_citation_dois)
+        # Dataset citations, these are any kind of citation of a dataset, but still
+        # could be useful information, so have ranked lower than the above two.
+        dataset_citation_dois = build_relations_query(
+            "relations.dataset_citation_dois",
+            "relations.dataset_citation_dois.doi",
+            [work.doi for work in published_outputs],
+            boost=2.5,
+        )
+        if dataset_citation_dois is not None:
+            must.append(dataset_citation_dois)
+
+    if not must:
+        log.warning(
+            f"No must-clause features produced a clause for DMP {dmp.doi}. "
+            f"Disabled features: {features.disabled_names()}. DMP will return zero results."
+        )
 
     # Final query and filter based on date range
     # also remove DMPs from search results (OUTPUT_MANAGEMENT_PLAN)
@@ -306,185 +359,6 @@ def build_dmp_works_search_baseline_query(
                         }
                     }
                 ],
-                "should": should,
-                "filter": filters,
-            },
-        },
-    }
-
-    if content:
-        query["highlight"] = {
-            "pre_tags": ["<mark>"],
-            "post_tags": ["</mark>"],
-            "order": "score",
-            "require_field_match": True,
-            "fields": {
-                "title": {
-                    "type": "fvh",
-                    "number_of_fragments": 0,
-                    "fragment_size": 0,
-                    "no_match_size": 500,
-                },
-                "abstract_text": {
-                    "type": "fvh",
-                    "fragment_size": 160,
-                    "number_of_fragments": 2,
-                    "no_match_size": 160,
-                },
-            },
-            "highlight_query": {
-                "more_like_this": {
-                    "fields": ["title", "abstract_text"],
-                    "like": content,
-                    "min_term_freq": 1,
-                }
-            },
-        }
-
-    # print(json.dumps(query))
-
-    return query
-
-
-def build_dmp_works_search_candidate_query(
-    dmp: DMPModel, max_results: int, project_end_buffer_years: int, inner_hits_size: int
-) -> dict:
-    """Build a candidate query for DMP works search.
-
-    Args:
-        dmp: The DMP model.
-        max_results: The maximum number of results to return.
-        project_end_buffer_years: The number of years to buffer the project end date.
-        inner_hits_size: The size of inner hits to return for nested fields.
-
-    Returns:
-        dict: The OpenSearch query.
-    """
-    should = []
-
-    #
-    # should.append(
-    #     {
-    #         "multi_match": {
-    #             "type": "most_fields",
-    #             "query": f"{dmp.title} {dmp.abstract}",
-    #             "fields": ["title.shingles^1", "abstract.shingles^1"],
-    #             "operator": "or",
-    #             # "fuzziness": "AUTO",
-    #         }
-    #     }
-    # )
-
-    # Funded DOIs
-    if dmp.funded_dois:
-        should.append(
-            {
-                "constant_score": {
-                    "_name": "funded_dois",
-                    "boost": 15,
-                    "filter": {
-                        "ids": {"values": dmp.funded_dois},
-                    },
-                }
-            }
-        )
-
-    # Authors
-    authors = build_entity_query(
-        "authors",
-        "authors.orcid",
-        "authors.full",
-        dmp.authors,
-        lambda author: author.orcid,
-        lambda author: author.surname,
-        inner_hits_size=inner_hits_size,
-        name_slop=None,
-    )
-    if authors is not None:
-        should.append(authors)
-
-    # Institutions
-    institutions = build_entity_query(
-        "institutions",
-        "institutions.ror",
-        "institutions.name",
-        dmp.institutions,
-        lambda inst: inst.ror,
-        lambda inst: inst.name,
-        inner_hits_size=inner_hits_size,
-        name_slop=3,
-    )
-    if institutions is not None:
-        should.append(institutions)
-
-    # Funders
-    funders = build_entity_query(
-        "funders",
-        "funders.ror",
-        "funders.name",
-        dmp.funding,
-        lambda fund: fund.funder.ror,
-        lambda fund: fund.funder.name,
-        inner_hits_size=inner_hits_size,
-        name_slop=3,
-    )
-    if funders is not None:
-        should.append(funders)
-
-    # Awards
-    awards = build_awards_query(
-        "awards",
-        dmp.external_data.awards,
-        inner_hits_size=inner_hits_size,
-    )
-    if awards is not None:
-        should.append(awards)
-
-    # Title and abstract
-    content = make_content(dmp)
-    if content:
-        should.append(
-            {
-                "more_like_this": {
-                    "_name": "content",
-                    "fields": ["title", "abstract_text"],
-                    "like": content,
-                    "min_term_freq": 1,
-                }
-            }
-        )
-
-    # Final query and filter based on date range
-    # also remove DMPs from search results (OUTPUT_MANAGEMENT_PLAN)
-    filters = [
-        {
-            "bool": {
-                "must_not": {
-                    "term": {
-                        "work_type": "OUTPUT_MANAGEMENT_PLAN",
-                    }
-                }
-            },
-        }
-    ]
-    if dmp.project_start is not None and dmp.project_start >= pendulum.date(1990, 1, 1):
-        gte = dmp.project_start.format("YYYY-MM-DD")
-        lte = dmp.project_end.add(years=project_end_buffer_years).format("YYYY-MM-DD")
-        filters.append(
-            {
-                "range": {
-                    "publication_date": {
-                        "gte": gte,
-                        "lte": lte,
-                    },
-                }
-            }
-        )
-
-    query = {
-        "size": max_results,
-        "query": {
-            "bool": {
                 "should": should,
                 "filter": filters,
             },
@@ -572,6 +446,70 @@ def build_awards_query(
                     "bool": {
                         "minimum_should_match": 1,
                         "should": award_queries,
+                    }
+                },
+                "inner_hits": {
+                    "name": path,
+                    "size": inner_hits_size,
+                },
+            },
+        }
+
+    return None
+
+
+def build_raw_awards_query(
+    path: str,
+    funding: list[FundingItem],
+    inner_hits_size: int = 50,
+) -> dict | None:
+    """Build a nested OpenSearch query matching raw funding identifiers.
+
+    Used as a fallback when no parsed awards are available (e.g. for funders
+    that are not yet supported by an AwardID parser). Matches the raw values
+    of funding_opportunity_id, award_id, and funder_project_number directly
+    against the works index `awards.award_id` field.
+
+    Args:
+        path: Nested document path for awards.
+        funding: List of FundingItem objects containing raw identifiers.
+        inner_hits_size: Maximum number of matching nested documents to return.
+
+    Returns:
+        Nested query dict if any funding item has raw identifiers, otherwise None.
+    """
+    funder_queries = []
+    for fund in funding:
+        raw_ids = {raw for raw in (fund.funding_opportunity_id, fund.award_id, fund.funder_project_number) if raw}
+        if not raw_ids:
+            continue
+        queries = [
+            {
+                "constant_score": {
+                    "_name": f"awards.award_id.{raw_id}",
+                    "filter": {"term": {"awards.award_id": raw_id}},
+                    "boost": 10,
+                }
+            }
+            for raw_id in raw_ids
+        ]
+        funder_queries.append(
+            {
+                "dis_max": {
+                    "tie_breaker": 0,
+                    "queries": queries,
+                }
+            }
+        )
+
+    if len(funder_queries) > 0:
+        return {
+            "nested": {
+                "path": path,
+                "query": {
+                    "bool": {
+                        "minimum_should_match": 1,
+                        "should": funder_queries,
                     }
                 },
                 "inner_hits": {
@@ -732,12 +670,26 @@ def build_ltr_features(dmp: DMPModel):
     """
     published_outputs = dmp.published_outputs if dmp.published_outputs is not None else []
 
+    # Awards: use parsed external awards when available, otherwise fall back to
+    # raw funding identifiers so unsupported funders still contribute features.
+    if dmp.external_data.awards:
+        dmp_award_count = len(dmp.external_data.awards)
+        award_groups = build_sltr_awards_query(dmp.external_data.awards)
+    else:
+        funding_with_raw = [
+            fund
+            for fund in dmp.funding
+            if any([fund.funding_opportunity_id, fund.award_id, fund.funder_project_number])
+        ]
+        dmp_award_count = len(funding_with_raw)
+        award_groups = build_sltr_raw_awards_query(funding_with_raw)
+
     return {
         "content": [make_content(dmp)],
         "funded_dois": dmp.funded_dois,
         # Awards
-        "dmp_award_count": len(dmp.external_data.awards),
-        "award_groups": build_sltr_awards_query(dmp.external_data.awards),
+        "dmp_award_count": dmp_award_count,
+        "award_groups": award_groups,
         # Authors
         "dmp_author_count": len(dmp.authors),
         "author_orcids": list(
@@ -837,6 +789,37 @@ def build_sltr_awards_query(awards: list[Award]) -> list[dict]:
             }
         }
         queries.append(query)
+    return queries
+
+
+def build_sltr_raw_awards_query(funding: list[FundingItem]) -> list[dict]:
+    """Build SLTR query components for raw funding identifiers.
+
+    Fallback variant of build_sltr_awards_query used when no parsed awards are
+    available. Each funder contributes one nested terms query against
+    awards.award_id with its non-null raw identifiers.
+
+    Args:
+        funding: A list of FundingItem objects.
+
+    Returns:
+        list[dict]: A list of query components.
+    """
+    queries = []
+    for fund in funding:
+        raw_ids = [raw for raw in (fund.funding_opportunity_id, fund.award_id, fund.funder_project_number) if raw]
+        if not raw_ids:
+            continue
+        queries.append(
+            {
+                "constant_score": {
+                    "boost": 1,
+                    "filter": {"nested": {"path": "awards", "query": {"terms": {"awards.award_id": raw_ids}}}},
+                }
+            }
+        )
+    if not queries:
+        return [{"match_none": {}}]
     return queries
 
 

--- a/python/dmpworks/opensearch/rank_metrics.py
+++ b/python/dmpworks/opensearch/rank_metrics.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from collections.abc import Iterable
 import csv
+import functools
 import itertools
 import logging
 import pathlib
@@ -9,11 +10,15 @@ from typing import Any
 from ranx import Qrels, Run, evaluate
 
 from dmpworks.cli_utils import OpenSearchClientConfig, QueryBuilder
+from dmpworks.model.dmp_model import ResearchOutput
 from dmpworks.model.related_work_model import RelatedWork
 from dmpworks.opensearch.dmp_search import fetch_dmps
 from dmpworks.opensearch.dmp_works_search import search_dmp_works
-from dmpworks.opensearch.query_builder import get_query_builder
+from dmpworks.opensearch.query_builder import QueryFeatures, get_query_builder
 from dmpworks.opensearch.utils import make_opensearch_client
+
+DMP_DOI_COLUMN = "dmp_doi"
+WORK_DOI_COLUMN = "work_doi"
 
 
 def load_qrels_dict(file_path: pathlib.Path) -> dict:
@@ -31,11 +36,44 @@ def load_qrels_dict(file_path: pathlib.Path) -> dict:
         for row in reader:
             status = row["status"]
             if status == "ACCEPTED":
-                dmp_doi = row["dmpDoi"]
-                work_doi = row["workDoi"]
+                dmp_doi = row[DMP_DOI_COLUMN]
+                work_doi = row[WORK_DOI_COLUMN]
                 qrels_dict[dmp_doi][work_doi] = 1
 
     return qrels_dict
+
+
+def load_published_outputs_file(file_path: pathlib.Path) -> dict[str, list[str]]:
+    """Load a CSV of (dmp_doi, work_doi) pairs into a per-DMP list of work DOIs.
+
+    Args:
+        file_path: The path to the CSV file with ``dmp_doi,work_doi`` columns.
+
+    Returns:
+        dict[str, list[str]]: A dictionary mapping each DMP DOI to the list of associated work DOIs.
+    """
+    outputs: dict[str, list[str]] = defaultdict(list)
+    with file_path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            dmp_doi = row[DMP_DOI_COLUMN]
+            work_doi = row[WORK_DOI_COLUMN]
+            outputs[dmp_doi].append(work_doi)
+    return outputs
+
+
+def save_published_outputs_file(file_path: pathlib.Path, pairs: list[tuple[str, str]]) -> None:
+    """Save a list of (dmp_doi, work_doi) pairs as a CSV file.
+
+    Args:
+        file_path: The destination path for the CSV file.
+        pairs: A list of (dmp_doi, work_doi) tuples to write.
+    """
+    with file_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=[DMP_DOI_COLUMN, WORK_DOI_COLUMN])
+        writer.writeheader()
+        for dmp_doi, work_doi in pairs:
+            writer.writerow({DMP_DOI_COLUMN: dmp_doi, WORK_DOI_COLUMN: work_doi})
 
 
 def load_run_dict(related_works: Iterable[RelatedWork], dmp_dois: set[str] | None = None) -> dict:
@@ -83,6 +121,9 @@ def related_works_calculate_metrics(
     include_named_queries_score: bool = True,
     inner_hits_size: int = 50,
     ks: list[int] | None = None,
+    inject_published_outputs_file: pathlib.Path | None = None,
+    true_positive_published_outputs_file: pathlib.Path | None = None,
+    features: QueryFeatures | None = None,
 ):
     """Calculate rank metrics for related works search.
 
@@ -101,8 +142,20 @@ def related_works_calculate_metrics(
         include_named_queries_score: Whether to include named queries scores.
         inner_hits_size: The size of inner hits to return for nested fields.
         ks: A list of k values for metrics calculation (e.g., [10, 20, 100]).
+        inject_published_outputs_file: Path to a CSV (``dmp_doi,work_doi`` columns) whose rows
+            define the published_outputs used during search. When set, this file is the full
+            anchor spec: DMPs listed in it get their injected anchors, DMPs not listed get an
+            empty anchor set. Used to drive the DMP relations feature from a controlled anchor
+            set during benchmarking.
+        true_positive_published_outputs_file: When set, write a CSV of ``dmp_doi,work_doi`` pairs
+            for each returned work that is also in the ground truth. The output file format matches
+            ``inject_published_outputs_file`` and can be fed back in on a subsequent run.
+        features: Per-feature toggles for the baseline query. Defaults to all-on.
     """
     logging.info("Computing rank metrics...")
+    features = features if features is not None else QueryFeatures()
+    if features.disabled_names():
+        logging.info(f"Feature ablation — disabled: {features.disabled_names()}")
     client = make_opensearch_client(client_config)
     related_works_all = []
     dmps_metrics = []
@@ -117,7 +170,16 @@ def related_works_calculate_metrics(
     # Load ground truth file and get DMP DOIs
     qrels_dict_all = load_qrels_dict(ground_truth_file)
     dmp_dois = list(get_dmp_dois(qrels_dict_all))
-    query_builder = get_query_builder(query_builder_name)
+    query_builder = functools.partial(get_query_builder(query_builder_name), features=features)
+
+    # Load injected published outputs (if provided) and prepare TP collection
+    inject_map: dict[str, list[str]] | None = None
+    if inject_published_outputs_file is not None:
+        inject_map = load_published_outputs_file(inject_published_outputs_file)
+        logging.info(
+            f"Loaded injected published outputs for {len(inject_map)} DMPs from {inject_published_outputs_file}"
+        )
+    true_positive_pairs: list[tuple[str, str]] = []
 
     with fetch_dmps(
         client=client,
@@ -129,6 +191,12 @@ def related_works_calculate_metrics(
     ) as results:
         for dmp in results.dmps:
             logging.info(f"DMP: {dmp.doi}")
+
+            # Inject file = full anchor spec: listed DMPs use injected anchors,
+            # un-listed DMPs are cleared so the relations feature has nothing to match.
+            if inject_map is not None:
+                dmp.published_outputs = [ResearchOutput(doi=d) for d in inject_map.get(dmp.doi, [])]
+
             # Candidate search
             related_works = search_dmp_works(
                 client,
@@ -143,20 +211,47 @@ def related_works_calculate_metrics(
             )
             related_works_all += related_works
 
+            # Collect true positives for optional export
+            if true_positive_published_outputs_file is not None:
+                qrel_work_dois = qrels_dict_all.get(dmp.doi, {})
+                true_positive_pairs.extend(
+                    (dmp.doi, rw.work.doi) for rw in related_works if rw.work.doi in qrel_work_dois
+                )
+
             # Calculate metrics
             qrels_dmp = Qrels.from_dict({dmp.doi: qrels_dict_all[dmp.doi]})
             run_dmp = Run.from_dict(load_run_dict(related_works))
             row = {"dmp_doi": dmp.doi, "dmp_title": dmp.title, "n_outputs": len(qrels_dict_all[dmp.doi])}
             for k in ks:
-                row.update(evaluate(qrels_dmp, run_dmp, [f"map@{k}", f"ndcg@{k}", f"precision@{k}", f"recall@{k}"]))
+                row.update(
+                    evaluate(
+                        qrels_dmp,
+                        run_dmp,
+                        [f"map@{k}", f"ndcg@{k}", f"precision@{k}", f"recall@{k}"],
+                        make_comparable=True,
+                    )
+                )
             dmps_metrics.append(row)
 
     # Calculate global metrics
     qrels_all = Qrels.from_dict(qrels_dict_all)
     run_all = Run.from_dict(load_run_dict(related_works_all))
+    missing_from_run = set(qrels_all.keys()) - set(run_all.keys())
+    if missing_from_run:
+        logging.warning(
+            f"{len(missing_from_run)} DMP(s) in the ground truth had no returned works "
+            f"(recall=0 for these): {sorted(missing_from_run)}"
+        )
     metrics_all: dict[str, Any] = {"dmp_doi": "all"}
     for k in ks:
-        metrics_all.update(evaluate(qrels_all, run_all, [f"map@{k}", f"ndcg@{k}", f"precision@{k}", f"recall@{k}"]))
+        metrics_all.update(
+            evaluate(
+                qrels_all,
+                run_all,
+                [f"map@{k}", f"ndcg@{k}", f"precision@{k}", f"recall@{k}"],
+                make_comparable=True,
+            )
+        )
 
     # Save metrics
     logging.info(f"Saving metrics to: {output_file}")
@@ -165,3 +260,11 @@ def related_works_calculate_metrics(
         writer.writeheader()
         writer.writerow(metrics_all)
         writer.writerows(dmps_metrics)
+
+    # Save true positive published outputs
+    if true_positive_published_outputs_file is not None:
+        logging.info(
+            f"Saving {len(true_positive_pairs)} true positive (dmp_doi, work_doi) pairs to: "
+            f"{true_positive_published_outputs_file}"
+        )
+        save_published_outputs_file(true_positive_published_outputs_file, true_positive_pairs)

--- a/python/dmpworks/opensearch/sync_dmps.py
+++ b/python/dmpworks/opensearch/sync_dmps.py
@@ -93,30 +93,37 @@ funding AS (
     temp.plan_id,
     JSON_ARRAYAGG(
       JSON_OBJECT(
-        'plan_funding_id', temp.plan_funding_id,
+        'project_funding_id', temp.project_funding_id,
         'funder_name', temp.funder_name,
         'funder_id', temp.funder_id,
         'funder_opportunity_id', temp.funder_opportunity_id,
         'grant_id', temp.grant_id,
+        'funder_project_number', temp.funder_project_number,
         'status', temp.status,
         'created', temp.created
       )
     ) AS funding
   FROM (
-    SELECT
+    SELECT DISTINCT
       pl.id AS plan_id,
-      plf.id AS plan_funding_id,
+      prf.id AS project_funding_id,
       af.name AS funder_name,
       prf.affiliationId AS funder_id,
       prf.funderOpportunityNumber AS funder_opportunity_id,
       prf.grantId AS grant_id,
+      prf.funderProjectNumber AS funder_project_number,
       prf.status,
-      plf.created
+      prf.created
     FROM unique_plans pl
-    INNER JOIN planFundings plf ON plf.planId = pl.id
-    INNER JOIN projectFundings prf ON prf.id = plf.projectFundingId
+    INNER JOIN projectFundings prf ON prf.projectId = pl.projectId
     LEFT JOIN affiliations af ON af.uri = prf.affiliationId
-    WHERE COALESCE(af.name, prf.affiliationId, prf.funderOpportunityNumber, prf.grantId) IS NOT NULL
+    WHERE COALESCE(
+      af.name,
+      prf.affiliationId,
+      prf.funderOpportunityNumber,
+      prf.grantId,
+      prf.funderProjectNumber
+    ) IS NOT NULL
   ) AS temp
   GROUP BY temp.plan_id
 ),
@@ -154,6 +161,8 @@ published_outputs_modified AS (
 )
 
 SELECT
+  pl.projectId AS project_id,
+  pl.id AS plan_id,
   pl.dmpId AS doi,
   pl.created,
   pl.registered,

--- a/python/dmpworks/scheduler/dynamodb_store.py
+++ b/python/dmpworks/scheduler/dynamodb_store.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import logging
 import os
 from typing import TYPE_CHECKING, Literal
@@ -708,6 +708,50 @@ def get_latest_process_dmps_run(*, release_date: str) -> ProcessDMPsRunRecord | 
         The most recent ProcessDMPsRunRecord, or None if no records exist.
     """
     return get_latest(ProcessDMPsRunRecord, release_date)
+
+
+def get_latest_process_works_run_recent(*, lookback_days: int = 90) -> ProcessWorksRunRecord | None:
+    """Return the most recent ProcessWorksRunRecord within a lookback window.
+
+    Scans the process-works-runs table filtered to release_dates within the last
+    ``lookback_days`` and returns the row with the greatest (release_date, run_id).
+    Used by the scheduled process-dmps guard to detect in-flight process-works runs
+    without scanning the whole table.
+
+    Args:
+        lookback_days: Days of history to consider. Defaults to 90 — process-works
+            runs monthly, so this window reliably captures the most recent run.
+
+    Returns:
+        The most recent ProcessWorksRunRecord within the window, or None if none exist.
+    """
+    start_date = (datetime.now(UTC) - timedelta(days=lookback_days)).date().isoformat()
+    runs = scan_all_process_works_runs(start_date=start_date)
+    if not runs:
+        return None
+    return max(runs, key=lambda r: (r.release_date, r.run_id))
+
+
+def get_latest_process_dmps_run_recent(*, lookback_days: int = 30) -> ProcessDMPsRunRecord | None:
+    """Return the most recent ProcessDMPsRunRecord within a lookback window.
+
+    Scans the process-dmps-runs table filtered to release_dates within the last
+    ``lookback_days`` and returns the row with the greatest (release_date, run_id).
+    Used by the scheduled process-dmps guard to detect in-flight process-dmps runs
+    without scanning the whole table.
+
+    Args:
+        lookback_days: Days of history to consider. Defaults to 30 — process-dmps
+            runs daily, so anything older cannot legitimately still be in flight.
+
+    Returns:
+        The most recent ProcessDMPsRunRecord within the window, or None if none exist.
+    """
+    start_date = (datetime.now(UTC) - timedelta(days=lookback_days)).date().isoformat()
+    runs = scan_all_process_dmps_runs(start_date=start_date)
+    if not runs:
+        return None
+    return max(runs, key=lambda r: (r.release_date, r.run_id))
 
 
 def set_process_dmps_run_status(

--- a/python/dmpworks/scheduler/handler/dmps/start_process_dmps_handler.py
+++ b/python/dmpworks/scheduler/handler/dmps/start_process_dmps_handler.py
@@ -10,9 +10,17 @@ if TYPE_CHECKING:
 
 import pendulum
 
+from dmpworks.scheduler.dynamodb_store import (
+    get_latest_process_dmps_run,
+    get_latest_process_dmps_run_recent,
+    get_latest_process_works_run_recent,
+)
 from dmpworks.scheduler.handler.start_execution import start_execution
 
 logging.getLogger().setLevel(logging.INFO)
+log = logging.getLogger(__name__)
+
+BLOCKING_STATUSES = frozenset({"STARTED", "WAITING_FOR_APPROVAL", "FAILED"})
 
 
 def start_process_dmps_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:  # noqa: ARG001
@@ -21,13 +29,53 @@ def start_process_dmps_handler(event: dict[str, Any], context: LambdaContext) ->
     Uses today's UTC date as the release_date, then starts the ProcessDmpsStateMachine.
     Sets run_all_dmps to False so the modification window filter applies.
 
+    Before starting, checks DynamoDB to ensure no process-works or process-dmps run is
+    still in flight. Skips (returns without starting) if:
+      - The latest process-works run is in a blocking state (STARTED, WAITING_FOR_APPROVAL, FAILED).
+      - The latest process-dmps run is in a blocking state.
+      - The latest process-works completed, but its chained process-dmps (matched by
+        release_date equality) has not yet completed.
+
     Args:
         event: EventBridge scheduled event (passed through; no required fields).
         context: Lambda context.
 
     Returns:
-        Dict with execution_arn and release_date.
+        Dict with execution_arn and release_date, or a dict with skipped=True and a reason
+        when the guard prevents a new execution.
     """
+    latest_works = get_latest_process_works_run_recent()
+    if latest_works is not None and latest_works.status in BLOCKING_STATUSES:
+        reason = f"process-works {latest_works.status}"
+        log.info(
+            f"Skipping process-dmps: {reason} "
+            f"(release_date={latest_works.release_date}, run_id={latest_works.run_id})"
+        )
+        return {"skipped": True, "reason": reason}
+
+    latest_dmps = get_latest_process_dmps_run_recent()
+    if latest_dmps is not None and latest_dmps.status in BLOCKING_STATUSES:
+        reason = f"process-dmps {latest_dmps.status}"
+        log.info(
+            f"Skipping process-dmps: previous {reason} "
+            f"(release_date={latest_dmps.release_date}, run_id={latest_dmps.run_id})"
+        )
+        return {"skipped": True, "reason": reason}
+
+    if latest_works is not None and latest_works.status == "COMPLETED":
+        if latest_dmps is not None and latest_dmps.release_date == latest_works.release_date:
+            chained = latest_dmps
+        else:
+            chained = get_latest_process_dmps_run(release_date=latest_works.release_date)
+        if chained is None or chained.status in BLOCKING_STATUSES:
+            chained_status = "missing" if chained is None else chained.status
+            reason = f"chained process-dmps {chained_status}"
+            log.info(
+                f"Skipping process-dmps: chained run for process-works "
+                f"release_date={latest_works.release_date} is {chained_status}"
+            )
+            return {"skipped": True, "reason": reason}
+
     release_date = pendulum.now("UTC").to_date_string()
     return start_execution(
         workflow_key="process-dmps",

--- a/python/dmpworks/transform/dmp.py
+++ b/python/dmpworks/transform/dmp.py
@@ -230,6 +230,7 @@ def parse_funding(objects: list[dict]) -> list[dict]:
         status = obj.get("status")
         funding_opportunity_id = replace_with_null(obj.get("funder_opportunity_id"), AWARD_IDS_EXCLUDE)
         award_id = replace_with_null(obj.get("grant_id"), AWARD_IDS_EXCLUDE)
+        funder_project_number = replace_with_null(obj.get("funder_project_number"), AWARD_IDS_EXCLUDE)
         funder = {
             "funder": {
                 "name": funder_name,
@@ -238,10 +239,11 @@ def parse_funding(objects: list[dict]) -> list[dict]:
             "status": status,
             "funding_opportunity_id": funding_opportunity_id,
             "award_id": award_id,
+            "funder_project_number": funder_project_number,
         }
 
-        if any([funder_name, funder_ror, funding_opportunity_id, award_id]):
-            key = (funder_name, funder_ror, status, funding_opportunity_id, award_id)
+        if any([funder_name, funder_ror, funding_opportunity_id, award_id, funder_project_number]):
+            key = (funder_name, funder_ror, status, funding_opportunity_id, award_id, funder_project_number)
             if key not in seen:
                 seen.add(key)
                 funding.append(funder)

--- a/tests/dmpworks/opensearch/test_cli.py
+++ b/tests/dmpworks/opensearch/test_cli.py
@@ -3,6 +3,7 @@ import pathlib
 
 from dmpworks.cli import cli
 from dmpworks.cli_utils import MySQLConfig, OpenSearchClientConfig, OpenSearchSyncConfig
+from dmpworks.opensearch.query_builder import QueryFeatures
 from opensearchpy import OpenSearch
 import pytest
 
@@ -167,7 +168,32 @@ class TestOpenSearchCLI:
             batch_size=100,
             max_results=100,
             ks=None,
+            inject_published_outputs_file=None,
+            true_positive_published_outputs_file=None,
+            features=QueryFeatures(),
         )
+
+    def test_opensearch_rank_metrics_disable_features(self, mock_rank_metrics, tmp_path: pathlib.Path):
+        gt_file = tmp_path / "ground_truth.csv"
+        gt_file.touch()
+        out_file = tmp_path / "metrics.json"
+
+        cli(
+            [
+                "opensearch",
+                "rank-metrics",
+                str(gt_file),
+                "dmps-index",
+                "works-index",
+                str(out_file),
+                "--disable-features",
+                "authors",
+                "institutions",
+            ]
+        )
+
+        passed_features = mock_rank_metrics.call_args.kwargs["features"]
+        assert passed_features == QueryFeatures(authors=False, institutions=False)
 
     @pytest.fixture
     def mock_create_featureset(self, mocker):

--- a/tests/dmpworks/opensearch/test_rank_metrics.py
+++ b/tests/dmpworks/opensearch/test_rank_metrics.py
@@ -1,0 +1,44 @@
+import pathlib
+
+import pytest
+
+from dmpworks.opensearch.rank_metrics import load_published_outputs_file, save_published_outputs_file
+
+
+class TestPublishedOutputsFileRoundtrip:
+    @pytest.mark.parametrize(
+        ("pairs", "expected"),
+        [
+            pytest.param(
+                [("10.0/dmp1", "10.0/work1"), ("10.0/dmp1", "10.0/work2"), ("10.0/dmp2", "10.0/work3")],
+                {"10.0/dmp1": ["10.0/work1", "10.0/work2"], "10.0/dmp2": ["10.0/work3"]},
+                id="multiple_dmps",
+            ),
+            pytest.param(
+                [("10.0/dmp1", "10.0/work1")],
+                {"10.0/dmp1": ["10.0/work1"]},
+                id="single_pair",
+            ),
+            pytest.param(
+                [],
+                {},
+                id="empty",
+            ),
+        ],
+    )
+    def test_roundtrip(self, tmp_path: pathlib.Path, pairs: list[tuple[str, str]], expected: dict[str, list[str]]):
+        file_path = tmp_path / "anchors.csv"
+        save_published_outputs_file(file_path, pairs)
+
+        loaded = load_published_outputs_file(file_path)
+
+        assert dict(loaded) == expected
+
+    def test_preserves_work_order(self, tmp_path: pathlib.Path):
+        file_path = tmp_path / "anchors.csv"
+        pairs = [("10.0/dmp1", f"10.0/work{i}") for i in range(5)]
+        save_published_outputs_file(file_path, pairs)
+
+        loaded = load_published_outputs_file(file_path)
+
+        assert loaded["10.0/dmp1"] == [f"10.0/work{i}" for i in range(5)]

--- a/tests/dmpworks/scheduler/handlers/dmps/test_start_process_dmps_handler.py
+++ b/tests/dmpworks/scheduler/handlers/dmps/test_start_process_dmps_handler.py
@@ -2,20 +2,30 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from dmpworks.scheduler.handler.dmps.start_process_dmps_handler import start_process_dmps_handler
 import pendulum
+import pytest
 
 PATCH_BASE = "dmpworks.scheduler.handler.dmps.start_process_dmps_handler"
 
 
-class TestStartExecution:
-    """start_process_dmps_handler computes the release date and delegates to start_execution."""
+def mock_record(*, status: str, release_date: str, run_id: str = "run-1"):
+    """Build a lightweight stand-in for a PynamoDB run record."""
+    return SimpleNamespace(status=status, release_date=release_date, run_id=run_id)
 
-    def test_passes_today_and_payload(self):
+
+class TestStartExecution:
+    """Happy path: no active runs, handler starts a new execution."""
+
+    def test_starts_execution_with_today_and_payload(self):
         with (
             patch(f"{PATCH_BASE}.pendulum") as mock_pendulum,
+            patch(f"{PATCH_BASE}.get_latest_process_works_run_recent", return_value=None),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run_recent", return_value=None),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run", return_value=None),
             patch(
                 f"{PATCH_BASE}.start_execution",
                 return_value={
@@ -43,3 +53,80 @@ class TestStartExecution:
             == "arn:aws:states:us-east-1:123456789012:execution:dmpworks-dev-process-dmps:exec-1"
         )
         assert result["release_date"] == "2025-01-15"
+
+    def test_runs_when_prior_runs_all_completed(self):
+        """A completed works run with a matching completed chained dmps does not block."""
+        works = mock_record(status="COMPLETED", release_date="2025-01-13")
+        chained = mock_record(status="COMPLETED", release_date="2025-01-13", run_id="chained-1")
+        latest_dmps = mock_record(status="COMPLETED", release_date="2025-01-14", run_id="dmps-1")
+
+        with (
+            patch(f"{PATCH_BASE}.pendulum") as mock_pendulum,
+            patch(f"{PATCH_BASE}.get_latest_process_works_run_recent", return_value=works),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run_recent", return_value=latest_dmps),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run", return_value=chained) as mock_chained,
+            patch(f"{PATCH_BASE}.start_execution", return_value={"execution_arn": "arn", "release_date": "2025-01-15"}),
+        ):
+            mock_pendulum.now.return_value = pendulum.parse("2025-01-15T10:00:00", tz="UTC")
+            result = start_process_dmps_handler({}, None)
+
+        mock_chained.assert_called_once_with(release_date="2025-01-13")
+        assert "skipped" not in result
+        assert result["release_date"] == "2025-01-15"
+
+    def test_reuses_latest_dmps_when_it_is_the_chained_run(self):
+        """When latest_dmps.release_date matches works.release_date, no second DDB query is issued."""
+        works = mock_record(status="COMPLETED", release_date="2025-01-13")
+        latest_dmps = mock_record(status="COMPLETED", release_date="2025-01-13", run_id="chained-1")
+
+        with (
+            patch(f"{PATCH_BASE}.pendulum") as mock_pendulum,
+            patch(f"{PATCH_BASE}.get_latest_process_works_run_recent", return_value=works),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run_recent", return_value=latest_dmps),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run") as mock_chained,
+            patch(f"{PATCH_BASE}.start_execution", return_value={"execution_arn": "arn", "release_date": "2025-01-15"}),
+        ):
+            mock_pendulum.now.return_value = pendulum.parse("2025-01-15T10:00:00", tz="UTC")
+            result = start_process_dmps_handler({}, None)
+
+        mock_chained.assert_not_called()
+        assert "skipped" not in result
+
+
+class TestGuardSkips:
+    """Guard skips a new execution when a prior run is still in flight or failed."""
+
+    @pytest.mark.parametrize(
+        "works_status,dmps_status,chained,expected_reason_prefix",
+        [
+            ("STARTED", "COMPLETED", "COMPLETED", "process-works STARTED"),
+            ("WAITING_FOR_APPROVAL", "COMPLETED", "COMPLETED", "process-works WAITING_FOR_APPROVAL"),
+            ("FAILED", "COMPLETED", "COMPLETED", "process-works FAILED"),
+            ("COMPLETED", "STARTED", "COMPLETED", "process-dmps STARTED"),
+            ("COMPLETED", "FAILED", "COMPLETED", "process-dmps FAILED"),
+            ("COMPLETED", "WAITING_FOR_APPROVAL", "COMPLETED", "process-dmps WAITING_FOR_APPROVAL"),
+            ("COMPLETED", "COMPLETED", None, "chained process-dmps missing"),
+            ("COMPLETED", "COMPLETED", "STARTED", "chained process-dmps STARTED"),
+            ("COMPLETED", "COMPLETED", "FAILED", "chained process-dmps FAILED"),
+        ],
+    )
+    def test_skips_with_reason(self, works_status, dmps_status, chained, expected_reason_prefix):
+        works = mock_record(status=works_status, release_date="2025-01-13")
+        # latest_dmps must not match the works release_date when testing the chained path,
+        # otherwise the "latest_dmps BLOCKING" branch can fire first for non-COMPLETED chained cases.
+        latest_dmps = mock_record(status=dmps_status, release_date="2025-01-14", run_id="dmps-1")
+        chained_record = (
+            None if chained is None else mock_record(status=chained, release_date="2025-01-13", run_id="chained-1")
+        )
+
+        with (
+            patch(f"{PATCH_BASE}.get_latest_process_works_run_recent", return_value=works),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run_recent", return_value=latest_dmps),
+            patch(f"{PATCH_BASE}.get_latest_process_dmps_run", return_value=chained_record),
+            patch(f"{PATCH_BASE}.start_execution") as mock_start,
+        ):
+            result = start_process_dmps_handler({}, None)
+
+        mock_start.assert_not_called()
+        assert result["skipped"] is True
+        assert result["reason"] == expected_reason_prefix

--- a/tests/dmpworks/test_cli.py
+++ b/tests/dmpworks/test_cli.py
@@ -21,7 +21,7 @@ class TestCLIEnvFile:
 
         cli.meta(["--env-file", str(env_file)] + subcommand_tokens)
 
-        mock_load_dotenv.assert_called_once_with(dotenv_path=env_file, override=True)
+        mock_load_dotenv.assert_called_once_with(dotenv_path=env_file, override=False)
 
     def test_dmpworks_env_var_loads_dotenv(self, mocker, monkeypatch, subcommand_tokens, tmp_path):
         mock_load_dotenv = mocker.patch("dmpworks.cli.load_dotenv")
@@ -32,7 +32,7 @@ class TestCLIEnvFile:
 
         cli.meta(subcommand_tokens)
 
-        mock_load_dotenv.assert_called_once_with(dotenv_path=env_file, override=True)
+        mock_load_dotenv.assert_called_once_with(dotenv_path=env_file, override=False)
 
     def test_missing_env_file_skips_load(self, mocker, subcommand_tokens, tmp_path):
         mock_load_dotenv = mocker.patch("dmpworks.cli.load_dotenv")


### PR DESCRIPTION
These are a few updates I made preparing for the demo:
- Script for calculating ranking metrics.
- Architecture diagram.
- CLI env var fix - environment variables should take priority over dot env.
- Some changes in the CLI and baseline query to re-generate metrics files.
- Realised there was a pretty bad regression in `python/dmpworks/opensearch/sync_dmps.py` which meant that award IDs and funding info weren't populated in OpenSearch `dmps-index`.
- Added a guard to `start_process_dmps_handler` that stops daily process dmps from running if process works is running.