### PR TITLE
Bug/dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# dmptool-works-matching change log
+
+## 2026-06-25
+- Update Dockerfile.builder to use the AWS public ECR instead of Dockerhub for the amazonlinux 2023 base image
+

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@
 # Compile Rust extension and build dmpworks wheel
 # -----------------------------------------------------
 
-FROM amazonlinux:2023
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 # Build arguments
 ARG RUST_TARGET_CPU="x86-64-v3"


### PR DESCRIPTION
Update Dockerfile to pull amazonlinux 2023 base image from the AWS public ECR

@jupiter007 the build is failing intermittently for this one due to that issue we've talked about in the AWS meeting where we get rate limit errors when trying to pull directly from Dockerhub.