### PR TITLE
update py03 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## 2026-06-25
 - Update Dockerfile.builder to use the AWS public ECR instead of Dockerhub for the amazonlinux 2023 base image
+- Update py03 rust dependency version
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "dmpworks_rust"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28.2", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["extension-module", "abi3-py39"] }
 human_name = "2.0.4"
 strip-tags = "0.1.0"
 log = "0.4"


### PR DESCRIPTION
The GitHub actions flagged the `py03` version as a sec vulnerability. This PR updates it to a patched version.